### PR TITLE
Ndlano/issue#220 version updates scala elastic search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.8
+  - 2.12.1
 jdk:
   - oraclejdk8
 # Use container-based infrastructure

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,7 +13,7 @@ API for accessing articles from NDLA
     sbt test
      
     #Tests that need a running elasticsearch outside of component, e.g. in your local docker.
-    sbt "test-only -- -n no.ndla.tag.articleapi.IntegrationTest"
+    sbt "test-only -- -n no.ndla.tag.IntegrationTest"
 
 ## Create Docker Image
     sbt docker

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -9,7 +9,11 @@ API for accessing articles from NDLA
     sbt compile
 
 ## Run tests
+    #All tests except Tagged tests
     sbt test
+     
+    #Tests that need a running elasticsearch outside of component, e.g. in your local docker.
+    sbt "test-only -- -n no.ndla.articleapi.tag.ESIntegrationTest"
 
 ## Create Docker Image
     sbt docker

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,8 +11,15 @@ API for accessing articles from NDLA
 ## Run tests
     #All tests except Tagged tests
     sbt test
-     
-    #Tests that need a running elasticsearch outside of component, e.g. in your local docker.
+### IntegrationTest Tag and sbt run problems
+Tests that need a running elasticsearch outside of component, e.g. in your local docker are marked with selfdefined java
+annotation test tag  ```IntegrationTag``` in ```/ndla/article-api/src/test/java/no/ndla/tag/IntegrationTest.java```. 
+As of now we have no running elasticserach og tunnel to one on Travis and need to not run these tests there or the build will fail. 
+Therefore we have the ```testOptions in Test += Tests.Argument("-l", "no.ndla.tag.IntegrationTest")``` in ```build.sbt```  
+This, it seems, will unfortunalty override runs on your local commandline so that ```sbt "test-only -- -n no.ndla.tag.IntegrationTest"```
+ will not run unless this line gets commented out or you comment out the ```@IntegrationTest``` annotation in ```SearchServiceTest.scala```
+ This should be solved better!
+
     sbt "test-only -- -n no.ndla.tag.IntegrationTest"
 
 ## Create Docker Image

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,7 +13,7 @@ API for accessing articles from NDLA
     sbt test
      
     #Tests that need a running elasticsearch outside of component, e.g. in your local docker.
-    sbt "test-only -- -n no.ndla.tag.ESIntegrationTest"
+    sbt "test-only -- -n no.ndla.tag.articleapi.IntegrationTest"
 
 ## Create Docker Image
     sbt docker

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,7 +13,7 @@ API for accessing articles from NDLA
     sbt test
      
     #Tests that need a running elasticsearch outside of component, e.g. in your local docker.
-    sbt "test-only -- -n no.ndla.articleapi.tag.ESIntegrationTest"
+    sbt "test-only -- -n no.ndla.tag.ESIntegrationTest"
 
 ## Create Docker Image
     sbt docker

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val article_api = (project in file(".")).
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions := Seq("-target:jvm-1.8"),
     libraryDependencies ++= Seq(
-      "ndla" %% "network" % "0.13",
+      "ndla" %% "network" % "0.16",
       "ndla" %% "mapping" % "0.4",
       "joda-time" % "joda-time" % "2.8.2",
       "org.scalatra" %% "scalatra" % Scalatraversion,

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ assemblyMergeStrategy in assembly := {
 }
 
 // Don't run Integration tests in default run
-testOptions in Test += Tests.Argument("-l", "no.ndla.IntegrationTest")
+testOptions in Test += Tests.Argument("-l", "no.ndla.imageapi.ESIntegrationTest")
 
 // Make the docker task depend on the assembly task, which generates a fat JAR file
 docker <<= (docker dependsOn assembly)

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ lazy val article_api = (project in file(".")).
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions := Seq("-target:jvm-1.8"),
     libraryDependencies ++= Seq(
-      "ndla" %% "network" % "0.12",
-      "ndla" %% "mapping" % "0.3",
+      "ndla" %% "network" % "0.13",
+      "ndla" %% "mapping" % "0.4",
       "joda-time" % "joda-time" % "2.8.2",
       "org.scalatra" %% "scalatra" % Scalatraversion,
       "org.eclipse.jetty" % "jetty-webapp" % Jettyversion % "container;compile",

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ lazy val article_api = (project in file(".")).
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions := Seq("-target:jvm-1.8"),
     libraryDependencies ++= Seq(
-      "ndla" %% "network" % "0.12-SNAPSHOT", //vårt lib - må releases først https://github.com/NDLANO/network/pull/10
-      "ndla" %% "mapping" % "0.3-SNAPSHOT",  //vårt lib - må releases først https://github.com/NDLANO/mapping/pull/2
+      "ndla" %% "network" % "0.12",
+      "ndla" %% "mapping" % "0.3",
       "joda-time" % "joda-time" % "2.8.2",
       "org.scalatra" %% "scalatra" % Scalatraversion,
       "org.eclipse.jetty" % "jetty-webapp" % Jettyversion % "container;compile",

--- a/build.sbt
+++ b/build.sbt
@@ -81,8 +81,12 @@ assemblyMergeStrategy in assembly := {
     oldStrategy(x)
 }
 
-// Don't run Integration tests in default run
-testOptions in Test += Tests.Argument("-l", "no.ndla.tag.ESIntegrationTest")
+// Don't run Integration tests in default run on Travis as there is no elasticsearch localhost:9200 there yet. 
+// NB this thing will unfortunalty overrade runs on your local commandline so that
+// sbt "test-only -- -n no.ndla.tag.IntegrationTest"
+// will not run unless this line gets commented out or you change the tag in UnitSuite.scala
+// This should be solved better!
+testOptions in Test += Tests.Argument("-l", "no.ndla.tag.IntegrationTest")
 
 // Make the docker task depend on the assembly task, which generates a fat JAR file
 docker <<= (docker dependsOn assembly)

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ assemblyMergeStrategy in assembly := {
 }
 
 // Don't run Integration tests in default run
-testOptions in Test += Tests.Argument("-l", "no.ndla.articleapi.ESIntegrationTest")
+testOptions in Test += Tests.Argument("-l", "no.ndla.articleapi.tag.ESIntegrationTest")
 
 // Make the docker task depend on the assembly task, which generates a fat JAR file
 docker <<= (docker dependsOn assembly)

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,15 @@
 import java.util.Properties
 
+val AwsSdkversion = "1.10.26"
+val Elastic4sVersion = "5.2.7"
+val ElasticsearchVersion = "5.1.1"
+val Jettyversion = "9.2.10.v20150310"
+val Log4JVersion = "2.7"
+val MockitoVersion = "1.10.19"
 val Scalaversion = "2.12.1"
 val Scalatraversion = "2.5.0"
 val ScalaLoggingVersion = "3.5.0"
-val Log4JVersion = "2.7"
-val Jettyversion = "9.2.10.v20150310"
-val AwsSdkversion = "1.10.26"
 val ScalaTestVersion = "3.0.1"
-val MockitoVersion = "1.10.19"
 
 val appProperties = settingKey[Properties]("The application properties")
 
@@ -30,8 +32,8 @@ lazy val article_api = (project in file(".")).
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions := Seq("-target:jvm-1.8"),
     libraryDependencies ++= Seq(
-      "ndla" %% "network" % "0.12-SNAPSHOT", //vårt lib - må oppdateres
-      "ndla" %% "mapping" % "0.3-SNAPSHOT", //vårt lib - må oppdateres
+      "ndla" %% "network" % "0.12-SNAPSHOT", //vårt lib - må releases først https://github.com/NDLANO/network/pull/10
+      "ndla" %% "mapping" % "0.3-SNAPSHOT",  //vårt lib - må releases først https://github.com/NDLANO/mapping/pull/2
       "joda-time" % "joda-time" % "2.8.2",
       "org.scalatra" %% "scalatra" % Scalatraversion,
       "org.eclipse.jetty" % "jetty-webapp" % Jettyversion % "container;compile",
@@ -50,12 +52,13 @@ lazy val article_api = (project in file(".")).
       "mysql" % "mysql-connector-java" % "5.1.36",
       "com.amazonaws" % "aws-java-sdk-s3" % AwsSdkversion,
       "org.scalaj" %% "scalaj-http" % "2.3.0",
-      "io.searchbox" % "jest" % "2.0.0", //
-      "org.elasticsearch" % "elasticsearch" % "5.1.1",
-      "com.sksamuel.elastic4s" %% "elastic4s-core" % "5.2.7", //
-      "org.elasticsearch" % "elasticsearch" % "5.1.1" % "test", //
-      "org.apache.lucene" % "lucene-test-framework" % "5.5.0" % "test", //
-      "vc.inreach.aws" % "aws-signing-request-interceptor" % "0.0.14", //signerer request mot aws sin elastic search
+      "io.searchbox" % "jest" % "2.0.4",
+      "org.elasticsearch" % "elasticsearch" % ElasticsearchVersion,
+      "com.sksamuel.elastic4s" %% "elastic4s-core" % Elastic4sVersion,
+      "com.sksamuel.elastic4s" %% "elastic4s-http" % Elastic4sVersion,
+      "org.elasticsearch" % "elasticsearch" % ElasticsearchVersion % "test",
+      "org.apache.lucene" % "lucene-test-framework" % "6.4.1" % "test",
+      "vc.inreach.aws" % "aws-signing-request-interceptor" % "0.0.16",
       "org.scalatest" %% "scalatest" % ScalaTestVersion % "test",
       "org.jsoup" % "jsoup" % "1.7.3",
       "org.mockito" % "mockito-all" % MockitoVersion % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,13 @@
 import java.util.Properties
 
-val Scalaversion = "2.11.8"
+val Scalaversion = "2.12.1"
 val Scalatraversion = "2.5.0"
-val SwaggerUIVersion = "2.0.24"
-val ScalaLoggingVersion = "3.1.0"
-val Log4JVersion = "2.6"
+val ScalaLoggingVersion = "3.5.0"
+val Log4JVersion = "2.7"
 val Jettyversion = "9.2.10.v20150310"
 val AwsSdkversion = "1.10.26"
-val ScalaTestVersion = "3.0.0"
+val ScalaTestVersion = "3.0.1"
 val MockitoVersion = "1.10.19"
-val SlickVersion = "3.0.0"
 
 val appProperties = settingKey[Properties]("The application properties")
 
@@ -32,8 +30,8 @@ lazy val article_api = (project in file(".")).
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions := Seq("-target:jvm-1.8"),
     libraryDependencies ++= Seq(
-      "ndla" %% "network" % "0.7",
-      "ndla" %% "mapping" % "0.2",
+      "ndla" %% "network" % "0.12-SNAPSHOT", //vårt lib - må oppdateres
+      "ndla" %% "mapping" % "0.3-SNAPSHOT", //vårt lib - må oppdateres
       "joda-time" % "joda-time" % "2.8.2",
       "org.scalatra" %% "scalatra" % Scalatraversion,
       "org.eclipse.jetty" % "jetty-webapp" % Jettyversion % "container;compile",
@@ -47,23 +45,22 @@ lazy val article_api = (project in file(".")).
       "org.apache.logging.log4j" % "log4j-api" % Log4JVersion,
       "org.apache.logging.log4j" % "log4j-core" % Log4JVersion,
       "org.apache.logging.log4j" % "log4j-slf4j-impl" % Log4JVersion,
-      "org.webjars" % "swagger-ui" % SwaggerUIVersion,
-      "org.scalikejdbc" %% "scalikejdbc" % "2.2.8",
+      "org.scalikejdbc" %% "scalikejdbc" % "2.5.0",
       "org.postgresql" % "postgresql" % "9.4-1201-jdbc4",
       "mysql" % "mysql-connector-java" % "5.1.36",
       "com.amazonaws" % "aws-java-sdk-s3" % AwsSdkversion,
-      "org.scalaj" %% "scalaj-http" % "1.1.5",
-      "io.searchbox" % "jest" % "2.0.0",
-      "org.elasticsearch" % "elasticsearch" % "2.3.3",
-      "com.sksamuel.elastic4s" %% "elastic4s-core" % "2.3.0",
-      "org.elasticsearch" % "elasticsearch" % "2.3.3" % "test",
-      "org.apache.lucene" % "lucene-test-framework" % "5.5.0" % "test",
-      "vc.inreach.aws" % "aws-signing-request-interceptor" % "0.0.14",
-      "org.scalatest" % "scalatest_2.11" % ScalaTestVersion % "test",
+      "org.scalaj" %% "scalaj-http" % "2.3.0",
+      "io.searchbox" % "jest" % "2.0.0", //
+      "org.elasticsearch" % "elasticsearch" % "5.1.1",
+      "com.sksamuel.elastic4s" %% "elastic4s-core" % "5.2.7", //
+      "org.elasticsearch" % "elasticsearch" % "5.1.1" % "test", //
+      "org.apache.lucene" % "lucene-test-framework" % "5.5.0" % "test", //
+      "vc.inreach.aws" % "aws-signing-request-interceptor" % "0.0.14", //signerer request mot aws sin elastic search
+      "org.scalatest" %% "scalatest" % ScalaTestVersion % "test",
       "org.jsoup" % "jsoup" % "1.7.3",
       "org.mockito" % "mockito-all" % MockitoVersion % "test",
       "org.flywaydb" % "flyway-core" % "4.0",
-      "com.netaporter" %% "scala-uri" % "0.4.12"
+      "com.netaporter" %% "scala-uri" % "0.4.16"
     )
   ).enablePlugins(DockerPlugin).enablePlugins(GitVersioning).enablePlugins(JettyPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ assemblyMergeStrategy in assembly := {
 }
 
 // Don't run Integration tests in default run
-testOptions in Test += Tests.Argument("-l", "no.ndla.imageapi.ESIntegrationTest")
+testOptions in Test += Tests.Argument("-l", "no.ndla.articleapi.ESIntegrationTest")
 
 // Make the docker task depend on the assembly task, which generates a fat JAR file
 docker <<= (docker dependsOn assembly)

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.util.Properties
 
 val AwsSdkversion = "1.10.26"
-val Elastic4sVersion = "5.2.7"
+val Elastic4sVersion = "5.2.8"
 val ElasticsearchVersion = "5.1.1"
 val Jettyversion = "9.2.10.v20150310"
 val Log4JVersion = "2.7"

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ assemblyMergeStrategy in assembly := {
 }
 
 // Don't run Integration tests in default run
-testOptions in Test += Tests.Argument("-l", "no.ndla.articleapi.tag.ESIntegrationTest")
+testOptions in Test += Tests.Argument("-l", "no.ndla.tag.ESIntegrationTest")
 
 // Make the docker task depend on the assembly task, which generates a fat JAR file
 docker <<= (docker dependsOn assembly)

--- a/build.sbt
+++ b/build.sbt
@@ -82,9 +82,9 @@ assemblyMergeStrategy in assembly := {
 }
 
 // Don't run Integration tests in default run on Travis as there is no elasticsearch localhost:9200 there yet. 
-// NB this thing will unfortunalty overrade runs on your local commandline so that
+// NB this line will unfortunalty override runs on your local commandline so that
 // sbt "test-only -- -n no.ndla.tag.IntegrationTest"
-// will not run unless this line gets commented out or you change the tag in UnitSuite.scala
+// will not run unless this line gets commented out or you remove the tag over the test class
 // This should be solved better!
 testOptions in Test += Tests.Argument("-l", "no.ndla.tag.IntegrationTest")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
 import java.util.Properties
 
-val AwsSdkversion = "1.10.26"
-val Elastic4sVersion = "5.2.8"
-val ElasticsearchVersion = "5.1.1"
-val Jettyversion = "9.2.10.v20150310"
-val Log4JVersion = "2.7"
-val MockitoVersion = "1.10.19"
 val Scalaversion = "2.12.1"
 val Scalatraversion = "2.5.0"
 val ScalaLoggingVersion = "3.5.0"
+val Log4JVersion = "2.7"
+val Jettyversion = "9.2.10.v20150310"
+val AwsSdkversion = "1.11.46"
 val ScalaTestVersion = "3.0.1"
+val MockitoVersion = "1.10.19"
+val Elastic4sVersion = "5.2.8"
+val ElasticsearchVersion = "5.1.1"
 
 val appProperties = settingKey[Properties]("The application properties")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.11
+sbt.version = 0.13.13

--- a/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -39,7 +39,7 @@ object ArticleApiProperties extends LazyLogging {
   val SearchServer = propOrElse("SEARCH_SERVER", "http://search-article-api.ndla-local")
   val SearchRegion = propOrElse("SEARCH_REGION", "eu-central-1")
   val RunWithSignedSearchRequests = propOrElse("RUN_WITH_SIGNED_SEARCH_REQUESTS", "true").toBoolean
-  val SearchIndex = "articles"
+  lazy val SearchIndex = propOrElse("SEARCH_ALIAS", "articles")
   val SearchDocument = "article"
   val DefaultPageSize = 10
   val MaxPageSize = 100

--- a/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
@@ -85,7 +85,7 @@ trait IndexService {
         languageSupportedField("tags"),
         dateField("lastUpdated"),
         keywordField("license") index "not_analyzed",
-        textField("authors")
+        textField("authors").fielddata(true)
       ), ArticleApiProperties.SearchDocument).string()
     }
 

--- a/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
@@ -12,8 +12,7 @@ package no.ndla.articleapi.service.search
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
-import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.mappings.FieldType.{DateType, IntegerType, StringType}
+import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.mappings.NestedFieldDefinition
 import com.typesafe.scalalogging.LazyLogging
 import io.searchbox.core.{Bulk, Index}
@@ -59,7 +58,10 @@ trait IndexService {
     }
 
     def createIndex(): Try[String] = {
-      val indexName = ArticleApiProperties.SearchIndex + "_" + getTimestamp
+      createIndexWithName(ArticleApiProperties.SearchIndex + "_" + getTimestamp)
+    }
+
+    def createIndexWithName(indexName: String): Try[String] = {
       if (indexExists(indexName).getOrElse(false)) {
         Success(indexName)
       } else {
@@ -73,25 +75,25 @@ trait IndexService {
       mappingResponse.map(_ => indexName)
     }
 
-    def buildMapping(): String = {
+    def buildMapping() = {
       mapping(ArticleApiProperties.SearchDocument).fields(
-        "id" typed IntegerType,
+        keywordField("id"),
         languageSupportedField("title", keepRaw = true),
         languageSupportedField("content"),
         languageSupportedField("visualElement"),
         languageSupportedField("introduction"),
         languageSupportedField("tags"),
-        "lastUpdated" typed DateType,
-        "license" typed StringType index "not_analyzed",
-        "authors" typed StringType
-      ).buildWithName.string()
+        dateField("lastUpdated"),
+        textField("license") index "not_analyzed",
+        textField("authors")
+      )
     }
 
     private def languageSupportedField(fieldName: String, keepRaw: Boolean = false) = {
       val languageSupportedField = new NestedFieldDefinition(fieldName)
       languageSupportedField._fields = keepRaw match {
-        case true => languageAnalyzers.map(langAnalyzer => langAnalyzer.lang typed StringType analyzer langAnalyzer.analyzer fields ("raw" typed StringType index "not_analyzed"))
-        case false => languageAnalyzers.map(langAnalyzer => langAnalyzer.lang typed StringType analyzer langAnalyzer.analyzer)
+        case true => languageAnalyzers.map(langAnalyzer => textField(langAnalyzer.lang) analyzer langAnalyzer.analyzer fields (textField("raw") index "not_analyzed"))
+        case false => languageAnalyzers.map(langAnalyzer => textField(langAnalyzer.lang) analyzer langAnalyzer.analyzer)
       }
 
       languageSupportedField

--- a/src/test/java/no/ndla/tag/IntegrationTest.java
+++ b/src/test/java/no/ndla/tag/IntegrationTest.java
@@ -1,0 +1,14 @@
+package no.ndla.tag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@org.scalatest.TagAnnotation
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface IntegrationTest {
+}

--- a/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -12,6 +12,8 @@ package no.ndla.articleapi
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar
 
+//Own tag for elasticsearch tests that need a running elasticsearch instance outside the test e.g. in the docker container
+object ESIntegrationTest extends Tag("no.ndla.imageapi.ESIntegrationTest")
 
 abstract class UnitSuite extends FunSuite with Matchers with OptionValues with Inside with Inspectors with MockitoSugar with BeforeAndAfterEach with BeforeAndAfterAll {
 

--- a/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -13,10 +13,10 @@ import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 
 /*
-Own tag for elasticsearch tests that need a running elasticsearch instance outside the test (e.g. in the docker container)
+Test tag for elasticsearch tests that will need a running elasticsearch instance outside the test (e.g. in the docker container)
 on port 9200.
 */
-object ESIntegrationTest extends Tag("no.ndla.tag.articleapi.IntegrationTest")
+object IntegrationTest extends Tag("no.ndla.tag.IntegrationTest")
 
 abstract class UnitSuite extends FunSuite with Matchers with OptionValues with Inside with Inspectors with MockitoSugar with BeforeAndAfterEach with BeforeAndAfterAll {
 

--- a/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -13,7 +13,7 @@ import org.scalatest._
 import org.scalatest.mock.MockitoSugar
 
 //Own tag for elasticsearch tests that need a running elasticsearch instance outside the test e.g. in the docker container
-object ESIntegrationTest extends Tag("no.ndla.imageapi.ESIntegrationTest")
+object ESIntegrationTest extends Tag("no.ndla.articleapi.ESIntegrationTest")
 
 abstract class UnitSuite extends FunSuite with Matchers with OptionValues with Inside with Inspectors with MockitoSugar with BeforeAndAfterEach with BeforeAndAfterAll {
 

--- a/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -10,10 +10,12 @@
 package no.ndla.articleapi
 
 import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 
-//Own tag for elasticsearch tests that need a running elasticsearch instance outside the test e.g. in the docker container
-object ESIntegrationTest extends Tag("no.ndla.articleapi.ESIntegrationTest")
+//Own tag for elasticsearch tests that need a running elasticsearch instance outside the test (e.g. in the docker container) on port 9200
+//The tag is not named no.ndla.articleapi.ESIntegrationTest due to the sbt test-only runner getting confused when it
+// matches package and will not run the tests as it then looks for package with given name as if it is a FunSuite instead of Tag.
+object ESIntegrationTest extends Tag("no.ndla.articleapi.tag.ESIntegrationTest")
 
 abstract class UnitSuite extends FunSuite with Matchers with OptionValues with Inside with Inspectors with MockitoSugar with BeforeAndAfterEach with BeforeAndAfterAll {
 

--- a/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -12,10 +12,11 @@ package no.ndla.articleapi
 import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 
-//Own tag for elasticsearch tests that need a running elasticsearch instance outside the test (e.g. in the docker container) on port 9200
-//The tag is not named no.ndla.articleapi.ESIntegrationTest due to the sbt test-only runner getting confused when it
-// matches package and will not run the tests as it then looks for package with given name as if it is a FunSuite instead of Tag.
-object ESIntegrationTest extends Tag("no.ndla.tag.ESIntegrationTest")
+/*
+Own tag for elasticsearch tests that need a running elasticsearch instance outside the test (e.g. in the docker container)
+on port 9200.
+*/
+object ESIntegrationTest extends Tag("no.ndla.tag.articleapi.IntegrationTest")
 
 abstract class UnitSuite extends FunSuite with Matchers with OptionValues with Inside with Inspectors with MockitoSugar with BeforeAndAfterEach with BeforeAndAfterAll {
 
@@ -32,6 +33,7 @@ abstract class UnitSuite extends FunSuite with Matchers with OptionValues with I
 
   setEnv("NDLA_BRIGHTCOVE_ACCOUNT_ID", "some-account-id")
   setEnv("NDLA_BRIGHTCOVE_PLAYER_ID", "some-player-id")
+  setEnv("SEARCH_ALIAS", "integration-test-index")
 
   def setEnv(key: String, value: String) = env.put(key, value)
 

--- a/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -15,7 +15,7 @@ import org.scalatest.mockito.MockitoSugar
 //Own tag for elasticsearch tests that need a running elasticsearch instance outside the test (e.g. in the docker container) on port 9200
 //The tag is not named no.ndla.articleapi.ESIntegrationTest due to the sbt test-only runner getting confused when it
 // matches package and will not run the tests as it then looks for package with given name as if it is a FunSuite instead of Tag.
-object ESIntegrationTest extends Tag("no.ndla.articleapi.tag.ESIntegrationTest")
+object ESIntegrationTest extends Tag("no.ndla.tag.ESIntegrationTest")
 
 abstract class UnitSuite extends FunSuite with Matchers with OptionValues with Inside with Inspectors with MockitoSugar with BeforeAndAfterEach with BeforeAndAfterAll {
 

--- a/src/test/scala/no/ndla/articleapi/UnitSuite.scala
+++ b/src/test/scala/no/ndla/articleapi/UnitSuite.scala
@@ -12,11 +12,6 @@ package no.ndla.articleapi
 import org.scalatest._
 import org.scalatest.mockito.MockitoSugar
 
-/*
-Test tag for elasticsearch tests that will need a running elasticsearch instance outside the test (e.g. in the docker container)
-on port 9200.
-*/
-object IntegrationTest extends Tag("no.ndla.tag.IntegrationTest")
 
 abstract class UnitSuite extends FunSuite with Matchers with OptionValues with Inside with Inspectors with MockitoSugar with BeforeAndAfterEach with BeforeAndAfterAll {
 

--- a/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
@@ -12,16 +12,12 @@ package no.ndla.articleapi.service.search
 import no.ndla.articleapi.integration.JestClientFactory
 import no.ndla.articleapi.model.domain._
 import no.ndla.articleapi._
-import org.elasticsearch.node.Node
 import org.joda.time.DateTime
 
-import scala.reflect.io.Path
 
 class SearchServiceTest extends UnitSuite with TestEnvironment {
 
   val esPort = 9200
-  val esDataDir = "esTestData"
-  var esNode: Node = _
 
   override val jestClient = JestClientFactory.getClient(searchServer = s"http://localhost:$esPort")
 
@@ -71,9 +67,7 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
   )
 
   override def beforeAll = {
-    Path(esDataDir).deleteRecursively()
-
-    val newIndex = indexService.createIndexWithName(ArticleApiProperties.SearchIndex)
+    indexService.createIndexWithName(ArticleApiProperties.SearchIndex)
 
     indexService.indexDocument(article1)
     indexService.indexDocument(article2)
@@ -84,7 +78,7 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
   }
 
   override def afterAll() = {
-    Path(esDataDir).deleteRecursively()
+    indexService.delete(Some(ArticleApiProperties.SearchIndex))
   }
 
   test("That getStartAtAndNumResults returns default values for None-input", ESIntegrationTest) {

--- a/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
@@ -12,9 +12,10 @@ package no.ndla.articleapi.service.search
 import no.ndla.articleapi.integration.JestClientFactory
 import no.ndla.articleapi.model.domain._
 import no.ndla.articleapi._
+import no.ndla.tag.IntegrationTest
 import org.joda.time.DateTime
 
-
+@IntegrationTest
 class SearchServiceTest extends UnitSuite with TestEnvironment {
 
   val esPort = 9200
@@ -81,76 +82,76 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     indexService.delete(Some(ArticleApiProperties.SearchIndex))
   }
 
-  test("That getStartAtAndNumResults returns default values for None-input", IntegrationTest) {
+  test("That getStartAtAndNumResults returns default values for None-input") {
     searchService.getStartAtAndNumResults(None, None) should equal((0, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That getStartAtAndNumResults returns SEARCH_MAX_PAGE_SIZE for value greater than SEARCH_MAX_PAGE_SIZE", IntegrationTest) {
+  test("That getStartAtAndNumResults returns SEARCH_MAX_PAGE_SIZE for value greater than SEARCH_MAX_PAGE_SIZE") {
     searchService.getStartAtAndNumResults(None, Some(1000)) should equal((0, ArticleApiProperties.MaxPageSize))
   }
 
-  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size with default page-size", IntegrationTest) {
+  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size with default page-size") {
     val page = 74
     val expectedStartAt = (page - 1) * ArticleApiProperties.DefaultPageSize
     searchService.getStartAtAndNumResults(Some(page), None) should equal((expectedStartAt, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size", IntegrationTest) {
+  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size") {
     val page = 123
     val expectedStartAt = (page - 1) * ArticleApiProperties.DefaultPageSize
     searchService.getStartAtAndNumResults(Some(page), Some(ArticleApiProperties.DefaultPageSize)) should equal((expectedStartAt, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That all returns all documents ordered by id ascending", IntegrationTest) {
+  test("That all returns all documents ordered by id ascending") {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdAsc)
     results.totalCount should be(3)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That all returns all documents ordered by id descending", IntegrationTest) {
+  test("That all returns all documents ordered by id descending") {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdDesc)
     results.totalCount should be(3)
     results.results.head.id should be("3")
     results.results.last.id should be("1")
   }
 
-  test("That all returns all documents ordered by title ascending", IntegrationTest) {
+  test("That all returns all documents ordered by title ascending") {
     val results = searchService.all(List(), None, None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(3)
     results.results.head.id should be("1")
     results.results.last.id should be("2")
   }
 
-  test("That all returns all documents ordered by lastUpdated descending", IntegrationTest) {
+  test("That all returns all documents ordered by lastUpdated descending") {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedDesc)
     results.totalCount should be(3)
     results.results.head.id should be("3")
     results.results.last.id should be("1")
   }
 
-  test("That all returns all documents ordered by lastUpdated ascending", IntegrationTest) {
+  test("That all returns all documents ordered by lastUpdated ascending") {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedAsc)
     results.totalCount should be(3)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That all filtering on license only returns documents with given license", IntegrationTest) {
+  test("That all filtering on license only returns documents with given license") {
     val results = searchService.all(List(), None, Some("publicdomain"), None, None, Sort.ByTitleAsc)
     results.totalCount should be(2)
     results.results.head.id should be("3")
     results.results.last.id should be("2")
   }
 
-  test("That all filtered by id only returns documents with the given ids", IntegrationTest) {
+  test("That all filtered by id only returns documents with the given ids") {
     val results = searchService.all(List(1, 3), None, None, None, None, Sort.ByIdAsc)
     results.totalCount should be(2)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That paging returns only hits on current page and not more than page-size", IntegrationTest) {
+  test("That paging returns only hits on current page and not more than page-size") {
     val page1 = searchService.all(List(), None, None, Some(1), Some(2), Sort.ByTitleAsc)
     val page2 = searchService.all(List(), None, None, Some(2), Some(2), Sort.ByTitleAsc)
     page1.totalCount should be(3)
@@ -164,38 +165,38 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     page2.results.head.id should be("2")
   }
 
-  test("That search matches title and html-content ordered by relevance descending", IntegrationTest) {
+  test("That search matches title and html-content ordered by relevance descending") {
     val results = searchService.matchingQuery(Seq("bil"), List(), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
     results.totalCount should be(2)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That search combined with filter by id only returns documents matching the query with one of the given ids", IntegrationTest) {
+  test("That search combined with filter by id only returns documents matching the query with one of the given ids") {
     val results = searchService.matchingQuery(Seq("bil"), List(3), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
     results.totalCount should be(1)
     results.results.head.id should be("3")
     results.results.last.id should be("3")
   }
 
-  test("That search matches title", IntegrationTest) {
+  test("That search matches title") {
     val results = searchService.matchingQuery(Seq("Pingvinen"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(1)
     results.results.head.id should be("2")
   }
 
-  test("That search matches tags", IntegrationTest) {
+  test("That search matches tags") {
     val results = searchService.matchingQuery(Seq("and"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(1)
     results.results.head.id should be("3")
   }
 
-  test("That search does not return superman since it has license copyrighted and license is not specified", IntegrationTest) {
+  test("That search does not return superman since it has license copyrighted and license is not specified") {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(0)
   }
 
-  test("That search returns superman since license is specified as copyrighted", IntegrationTest) {
+  test("That search returns superman since license is specified as copyrighted") {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), Some("copyrighted"), None, None, Sort.ByTitleAsc)
     results.totalCount should be(1)
     results.results.head.id should be("4")

--- a/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
@@ -11,9 +11,10 @@ package no.ndla.articleapi.service.search
 
 import no.ndla.articleapi.integration.JestClientFactory
 import no.ndla.articleapi.model.domain._
-import no.ndla.articleapi.{ArticleApiProperties, TestData, TestEnvironment, UnitSuite}
+import no.ndla.articleapi._
 import org.elasticsearch.node.Node
 import org.joda.time.DateTime
+
 import scala.reflect.io.Path
 
 class SearchServiceTest extends UnitSuite with TestEnvironment {
@@ -86,76 +87,76 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     Path(esDataDir).deleteRecursively()
   }
 
-  test("That getStartAtAndNumResults returns default values for None-input") {
+  test("That getStartAtAndNumResults returns default values for None-input", ESIntegrationTest) {
     searchService.getStartAtAndNumResults(None, None) should equal((0, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That getStartAtAndNumResults returns SEARCH_MAX_PAGE_SIZE for value greater than SEARCH_MAX_PAGE_SIZE") {
+  test("That getStartAtAndNumResults returns SEARCH_MAX_PAGE_SIZE for value greater than SEARCH_MAX_PAGE_SIZE", ESIntegrationTest) {
     searchService.getStartAtAndNumResults(None, Some(1000)) should equal((0, ArticleApiProperties.MaxPageSize))
   }
 
-  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size with default page-size") {
+  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size with default page-size", ESIntegrationTest) {
     val page = 74
     val expectedStartAt = (page - 1) * ArticleApiProperties.DefaultPageSize
     searchService.getStartAtAndNumResults(Some(page), None) should equal((expectedStartAt, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size") {
+  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size", ESIntegrationTest) {
     val page = 123
     val expectedStartAt = (page - 1) * ArticleApiProperties.DefaultPageSize
     searchService.getStartAtAndNumResults(Some(page), Some(ArticleApiProperties.DefaultPageSize)) should equal((expectedStartAt, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That all returns all documents ordered by id ascending") {
+  test("That all returns all documents ordered by id ascending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdAsc)
     results.totalCount should be (3)
     results.results.head.id should be ("1")
     results.results.last.id should be ("3")
   }
 
-  test("That all returns all documents ordered by id descending") {
+  test("That all returns all documents ordered by id descending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdDesc)
     results.totalCount should be (3)
     results.results.head.id should be ("3")
     results.results.last.id should be ("1")
   }
 
-  test("That all returns all documents ordered by title ascending") {
+  test("That all returns all documents ordered by title ascending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByTitleAsc)
     results.totalCount should be (3)
     results.results.head.id should be ("1")
     results.results.last.id should be ("2")
   }
 
-  test("That all returns all documents ordered by lastUpdated descending") {
+  test("That all returns all documents ordered by lastUpdated descending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedDesc)
     results.totalCount should be (3)
     results.results.head.id should be ("3")
     results.results.last.id should be ("1")
   }
 
-  test("That all returns all documents ordered by lastUpdated ascending") {
+  test("That all returns all documents ordered by lastUpdated ascending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedAsc)
     results.totalCount should be (3)
     results.results.head.id should be ("1")
     results.results.last.id should be ("3")
   }
 
-  test("That all filtering on license only returns documents with given license") {
+  test("That all filtering on license only returns documents with given license", ESIntegrationTest) {
     val results = searchService.all(List(), None, Some("publicdomain"), None, None, Sort.ByTitleAsc)
     results.totalCount should be (2)
     results.results.head.id should be ("3")
     results.results.last.id should be ("2")
   }
 
-  test("That all filtered by id only returns documents with the given ids") {
+  test("That all filtered by id only returns documents with the given ids", ESIntegrationTest) {
     val results = searchService.all(List(1,3), None, None, None, None, Sort.ByIdAsc)
     results.totalCount should be (2)
     results.results.head.id should be ("1")
     results.results.last.id should be ("3")
   }
 
-  test("That paging returns only hits on current page and not more than page-size") {
+  test("That paging returns only hits on current page and not more than page-size", ESIntegrationTest) {
     val page1 = searchService.all(List(), None, None, Some(1), Some(2), Sort.ByTitleAsc)
     val page2 = searchService.all(List(), None, None, Some(2), Some(2), Sort.ByTitleAsc)
     page1.totalCount should be (3)
@@ -169,38 +170,38 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     page2.results.head.id should be ("2")
   }
 
-  test("That search matches title and html-content ordered by relevance descending") {
+  test("That search matches title and html-content ordered by relevance descending", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("bil"), List(), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
     results.totalCount should be (2)
     results.results.head.id should be ("1")
     results.results.last.id should be ("3")
   }
 
-  test("That search combined with filter by id only returns documents matching the query with one of the given ids") {
+  test("That search combined with filter by id only returns documents matching the query with one of the given ids", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("bil"), List(3), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
     results.totalCount should be (1)
     results.results.head.id should be ("3")
     results.results.last.id should be ("3")
   }
 
-  test("That search matches title") {
+  test("That search matches title", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("Pingvinen"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be (1)
     results.results.head.id should be ("2")
   }
 
-  test("That search matches tags") {
+  test("That search matches tags", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("and"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be (1)
     results.results.head.id should be ("3")
   }
 
-  test("That search does not return superman since it has license copyrighted and license is not specified") {
+  test("That search does not return superman since it has license copyrighted and license is not specified", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be (0)
   }
 
-  test("That search returns superman since license is specified as copyrighted") {
+  test("That search returns superman since license is specified as copyrighted", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), Some("copyrighted"), None, None, Sort.ByTitleAsc)
     results.totalCount should be (1)
     results.results.head.id should be ("4")

--- a/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
@@ -36,38 +36,38 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
   val today = DateTime.now()
 
   val article1 = TestData.sampleArticleWithByNcSa.copy(
-    id=Option(1),
-    title=List(ArticleTitle("Batmen er på vift med en bil", Some("nb"))),
-    introduction=List(ArticleIntroduction("Batmen", Some("nb"))),
-    content=List(ArticleContent("Bilde av en <strong>bil</strong> flaggermusmann som vifter med vingene <em>bil</em>.", None, Some("nb"))),
-    tags=List(ArticleTag(List("fugl"), Some("nb"))),
-    created=today.minusDays(4).toDate,
-    updated=today.minusDays(3).toDate)
+    id = Option(1),
+    title = List(ArticleTitle("Batmen er på vift med en bil", Some("nb"))),
+    introduction = List(ArticleIntroduction("Batmen", Some("nb"))),
+    content = List(ArticleContent("Bilde av en <strong>bil</strong> flaggermusmann som vifter med vingene <em>bil</em>.", None, Some("nb"))),
+    tags = List(ArticleTag(List("fugl"), Some("nb"))),
+    created = today.minusDays(4).toDate,
+    updated = today.minusDays(3).toDate)
   val article2 = TestData.sampleArticleWithPublicDomain.copy(
-    id=Option(2),
-    title=List(ArticleTitle("Pingvinen er ute og går", Some("nb"))),
-    introduction=List(ArticleIntroduction("Pingvinen", Some("nb"))),
-    content=List(ArticleContent("<p>Bilde av en</p><p> en <em>pingvin</em> som vagger borover en gate</p>", None, Some("nb"))),
-    tags=List(ArticleTag(List("fugl"), Some("nb"))),
-    created=today.minusDays(4).toDate,
-    updated=today.minusDays(2).toDate)
+    id = Option(2),
+    title = List(ArticleTitle("Pingvinen er ute og går", Some("nb"))),
+    introduction = List(ArticleIntroduction("Pingvinen", Some("nb"))),
+    content = List(ArticleContent("<p>Bilde av en</p><p> en <em>pingvin</em> som vagger borover en gate</p>", None, Some("nb"))),
+    tags = List(ArticleTag(List("fugl"), Some("nb"))),
+    created = today.minusDays(4).toDate,
+    updated = today.minusDays(2).toDate)
   val article3 = TestData.sampleArticleWithPublicDomain.copy(
-    id=Option(3),
-    title=List(ArticleTitle("Donald Duck kjører bil", Some("nb"))),
-    introduction=List(ArticleIntroduction("Donald Duck", Some("nb"))),
-    content=List(ArticleContent("<p>Bilde av en en and</p><p> som <strong>kjører</strong> en rød bil.</p>", None, Some("nb"))),
-    tags=List(ArticleTag(List("and"), Some("nb"))),
-    created=today.minusDays(4).toDate,
-    updated=today.minusDays(1).toDate
+    id = Option(3),
+    title = List(ArticleTitle("Donald Duck kjører bil", Some("nb"))),
+    introduction = List(ArticleIntroduction("Donald Duck", Some("nb"))),
+    content = List(ArticleContent("<p>Bilde av en en and</p><p> som <strong>kjører</strong> en rød bil.</p>", None, Some("nb"))),
+    tags = List(ArticleTag(List("and"), Some("nb"))),
+    created = today.minusDays(4).toDate,
+    updated = today.minusDays(1).toDate
   )
   val article4 = TestData.sampleArticleWithCopyrighted.copy(
-    id=Option(4),
-    title=List(ArticleTitle("Superman er ute og flyr", Some("nb"))),
-    introduction=List(ArticleIntroduction("Superman", Some("nb"))),
-    content=List(ArticleContent("<p>Bilde av en flygende mann</p><p> som <strong>har</strong> superkrefter.</p>", None, Some("nb"))),
-    tags=List(ArticleTag(List("supermann"), Some("nb"))),
-    created=today.minusDays(4).toDate,
-    updated=today.toDate
+    id = Option(4),
+    title = List(ArticleTitle("Superman er ute og flyr", Some("nb"))),
+    introduction = List(ArticleIntroduction("Superman", Some("nb"))),
+    content = List(ArticleContent("<p>Bilde av en flygende mann</p><p> som <strong>har</strong> superkrefter.</p>", None, Some("nb"))),
+    tags = List(ArticleTag(List("supermann"), Some("nb"))),
+    created = today.minusDays(4).toDate,
+    updated = today.toDate
   )
 
   override def beforeAll = {
@@ -109,102 +109,102 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
 
   test("That all returns all documents ordered by id ascending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdAsc)
-    results.totalCount should be (3)
-    results.results.head.id should be ("1")
-    results.results.last.id should be ("3")
+    results.totalCount should be(3)
+    results.results.head.id should be("1")
+    results.results.last.id should be("3")
   }
 
   test("That all returns all documents ordered by id descending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdDesc)
-    results.totalCount should be (3)
-    results.results.head.id should be ("3")
-    results.results.last.id should be ("1")
+    results.totalCount should be(3)
+    results.results.head.id should be("3")
+    results.results.last.id should be("1")
   }
 
   test("That all returns all documents ordered by title ascending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByTitleAsc)
-    results.totalCount should be (3)
-    results.results.head.id should be ("1")
-    results.results.last.id should be ("2")
+    results.totalCount should be(3)
+    results.results.head.id should be("1")
+    results.results.last.id should be("2")
   }
 
   test("That all returns all documents ordered by lastUpdated descending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedDesc)
-    results.totalCount should be (3)
-    results.results.head.id should be ("3")
-    results.results.last.id should be ("1")
+    results.totalCount should be(3)
+    results.results.head.id should be("3")
+    results.results.last.id should be("1")
   }
 
   test("That all returns all documents ordered by lastUpdated ascending", ESIntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedAsc)
-    results.totalCount should be (3)
-    results.results.head.id should be ("1")
-    results.results.last.id should be ("3")
+    results.totalCount should be(3)
+    results.results.head.id should be("1")
+    results.results.last.id should be("3")
   }
 
   test("That all filtering on license only returns documents with given license", ESIntegrationTest) {
     val results = searchService.all(List(), None, Some("publicdomain"), None, None, Sort.ByTitleAsc)
-    results.totalCount should be (2)
-    results.results.head.id should be ("3")
-    results.results.last.id should be ("2")
+    results.totalCount should be(2)
+    results.results.head.id should be("3")
+    results.results.last.id should be("2")
   }
 
   test("That all filtered by id only returns documents with the given ids", ESIntegrationTest) {
-    val results = searchService.all(List(1,3), None, None, None, None, Sort.ByIdAsc)
-    results.totalCount should be (2)
-    results.results.head.id should be ("1")
-    results.results.last.id should be ("3")
+    val results = searchService.all(List(1, 3), None, None, None, None, Sort.ByIdAsc)
+    results.totalCount should be(2)
+    results.results.head.id should be("1")
+    results.results.last.id should be("3")
   }
 
   test("That paging returns only hits on current page and not more than page-size", ESIntegrationTest) {
     val page1 = searchService.all(List(), None, None, Some(1), Some(2), Sort.ByTitleAsc)
     val page2 = searchService.all(List(), None, None, Some(2), Some(2), Sort.ByTitleAsc)
-    page1.totalCount should be (3)
-    page1.page should be (1)
-    page1.results.size should be (2)
-    page1.results.head.id should be ("1")
-    page1.results.last.id should be ("3")
-    page2.totalCount should be (3)
-    page2.page should be (2)
-    page2.results.size should be (1)
-    page2.results.head.id should be ("2")
+    page1.totalCount should be(3)
+    page1.page should be(1)
+    page1.results.size should be(2)
+    page1.results.head.id should be("1")
+    page1.results.last.id should be("3")
+    page2.totalCount should be(3)
+    page2.page should be(2)
+    page2.results.size should be(1)
+    page2.results.head.id should be("2")
   }
 
   test("That search matches title and html-content ordered by relevance descending", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("bil"), List(), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
-    results.totalCount should be (2)
-    results.results.head.id should be ("1")
-    results.results.last.id should be ("3")
+    results.totalCount should be(2)
+    results.results.head.id should be("1")
+    results.results.last.id should be("3")
   }
 
   test("That search combined with filter by id only returns documents matching the query with one of the given ids", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("bil"), List(3), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
-    results.totalCount should be (1)
-    results.results.head.id should be ("3")
-    results.results.last.id should be ("3")
+    results.totalCount should be(1)
+    results.results.head.id should be("3")
+    results.results.last.id should be("3")
   }
 
   test("That search matches title", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("Pingvinen"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
-    results.totalCount should be (1)
-    results.results.head.id should be ("2")
+    results.totalCount should be(1)
+    results.results.head.id should be("2")
   }
 
   test("That search matches tags", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("and"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
-    results.totalCount should be (1)
-    results.results.head.id should be ("3")
+    results.totalCount should be(1)
+    results.results.head.id should be("3")
   }
 
   test("That search does not return superman since it has license copyrighted and license is not specified", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
-    results.totalCount should be (0)
+    results.totalCount should be(0)
   }
 
   test("That search returns superman since license is specified as copyrighted", ESIntegrationTest) {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), Some("copyrighted"), None, None, Sort.ByTitleAsc)
-    results.totalCount should be (1)
-    results.results.head.id should be ("4")
+    results.totalCount should be(1)
+    results.results.head.id should be("4")
   }
 
   def blockUntil(predicate: () => Boolean) = {

--- a/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/search/SearchServiceTest.scala
@@ -81,76 +81,76 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     indexService.delete(Some(ArticleApiProperties.SearchIndex))
   }
 
-  test("That getStartAtAndNumResults returns default values for None-input", ESIntegrationTest) {
+  test("That getStartAtAndNumResults returns default values for None-input", IntegrationTest) {
     searchService.getStartAtAndNumResults(None, None) should equal((0, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That getStartAtAndNumResults returns SEARCH_MAX_PAGE_SIZE for value greater than SEARCH_MAX_PAGE_SIZE", ESIntegrationTest) {
+  test("That getStartAtAndNumResults returns SEARCH_MAX_PAGE_SIZE for value greater than SEARCH_MAX_PAGE_SIZE", IntegrationTest) {
     searchService.getStartAtAndNumResults(None, Some(1000)) should equal((0, ArticleApiProperties.MaxPageSize))
   }
 
-  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size with default page-size", ESIntegrationTest) {
+  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size with default page-size", IntegrationTest) {
     val page = 74
     val expectedStartAt = (page - 1) * ArticleApiProperties.DefaultPageSize
     searchService.getStartAtAndNumResults(Some(page), None) should equal((expectedStartAt, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size", ESIntegrationTest) {
+  test("That getStartAtAndNumResults returns the correct calculated start at for page and page-size", IntegrationTest) {
     val page = 123
     val expectedStartAt = (page - 1) * ArticleApiProperties.DefaultPageSize
     searchService.getStartAtAndNumResults(Some(page), Some(ArticleApiProperties.DefaultPageSize)) should equal((expectedStartAt, ArticleApiProperties.DefaultPageSize))
   }
 
-  test("That all returns all documents ordered by id ascending", ESIntegrationTest) {
+  test("That all returns all documents ordered by id ascending", IntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdAsc)
     results.totalCount should be(3)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That all returns all documents ordered by id descending", ESIntegrationTest) {
+  test("That all returns all documents ordered by id descending", IntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByIdDesc)
     results.totalCount should be(3)
     results.results.head.id should be("3")
     results.results.last.id should be("1")
   }
 
-  test("That all returns all documents ordered by title ascending", ESIntegrationTest) {
+  test("That all returns all documents ordered by title ascending", IntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(3)
     results.results.head.id should be("1")
     results.results.last.id should be("2")
   }
 
-  test("That all returns all documents ordered by lastUpdated descending", ESIntegrationTest) {
+  test("That all returns all documents ordered by lastUpdated descending", IntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedDesc)
     results.totalCount should be(3)
     results.results.head.id should be("3")
     results.results.last.id should be("1")
   }
 
-  test("That all returns all documents ordered by lastUpdated ascending", ESIntegrationTest) {
+  test("That all returns all documents ordered by lastUpdated ascending", IntegrationTest) {
     val results = searchService.all(List(), None, None, None, None, Sort.ByLastUpdatedAsc)
     results.totalCount should be(3)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That all filtering on license only returns documents with given license", ESIntegrationTest) {
+  test("That all filtering on license only returns documents with given license", IntegrationTest) {
     val results = searchService.all(List(), None, Some("publicdomain"), None, None, Sort.ByTitleAsc)
     results.totalCount should be(2)
     results.results.head.id should be("3")
     results.results.last.id should be("2")
   }
 
-  test("That all filtered by id only returns documents with the given ids", ESIntegrationTest) {
+  test("That all filtered by id only returns documents with the given ids", IntegrationTest) {
     val results = searchService.all(List(1, 3), None, None, None, None, Sort.ByIdAsc)
     results.totalCount should be(2)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That paging returns only hits on current page and not more than page-size", ESIntegrationTest) {
+  test("That paging returns only hits on current page and not more than page-size", IntegrationTest) {
     val page1 = searchService.all(List(), None, None, Some(1), Some(2), Sort.ByTitleAsc)
     val page2 = searchService.all(List(), None, None, Some(2), Some(2), Sort.ByTitleAsc)
     page1.totalCount should be(3)
@@ -164,38 +164,38 @@ class SearchServiceTest extends UnitSuite with TestEnvironment {
     page2.results.head.id should be("2")
   }
 
-  test("That search matches title and html-content ordered by relevance descending", ESIntegrationTest) {
+  test("That search matches title and html-content ordered by relevance descending", IntegrationTest) {
     val results = searchService.matchingQuery(Seq("bil"), List(), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
     results.totalCount should be(2)
     results.results.head.id should be("1")
     results.results.last.id should be("3")
   }
 
-  test("That search combined with filter by id only returns documents matching the query with one of the given ids", ESIntegrationTest) {
+  test("That search combined with filter by id only returns documents matching the query with one of the given ids", IntegrationTest) {
     val results = searchService.matchingQuery(Seq("bil"), List(3), Some("nb"), None, None, None, Sort.ByRelevanceDesc)
     results.totalCount should be(1)
     results.results.head.id should be("3")
     results.results.last.id should be("3")
   }
 
-  test("That search matches title", ESIntegrationTest) {
+  test("That search matches title", IntegrationTest) {
     val results = searchService.matchingQuery(Seq("Pingvinen"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(1)
     results.results.head.id should be("2")
   }
 
-  test("That search matches tags", ESIntegrationTest) {
+  test("That search matches tags", IntegrationTest) {
     val results = searchService.matchingQuery(Seq("and"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(1)
     results.results.head.id should be("3")
   }
 
-  test("That search does not return superman since it has license copyrighted and license is not specified", ESIntegrationTest) {
+  test("That search does not return superman since it has license copyrighted and license is not specified", IntegrationTest) {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), None, None, None, Sort.ByTitleAsc)
     results.totalCount should be(0)
   }
 
-  test("That search returns superman since license is specified as copyrighted", ESIntegrationTest) {
+  test("That search returns superman since license is specified as copyrighted", IntegrationTest) {
     val results = searchService.matchingQuery(Seq("supermann"), List(), Some("nb"), Some("copyrighted"), None, None, Sort.ByTitleAsc)
     results.totalCount should be(1)
     results.results.head.id should be("4")


### PR DESCRIPTION
* Updated to newest versions to make ES5 and scala 2.12 work
* Due to ES no longer supporting embedded es node in testes, added new tag ESIntegrasionTest to let developers run it locally without running other eventual Integration tests.