### PR TITLE
#277 Route for csv report on html faults

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -9,17 +9,21 @@
 
 package no.ndla.articleapi.controller
 
-import no.ndla.articleapi.model.domain.ImportStatus
+import no.ndla.articleapi.integration.ConverterModule.stringToJsoupDocument
+import no.ndla.articleapi.model.domain.{HtmlFaultRapport, ImportStatus}
 import no.ndla.articleapi.repository.ArticleRepository
+import no.ndla.articleapi.service._
 import no.ndla.articleapi.service.search.SearchIndexService
-import no.ndla.articleapi.service.{ArticleContentInformation, ConverterService, ExtractConvertStoreContent, ExtractService}
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.{InternalServerError, Ok}
 
+import scala.collection.JavaConversions._
+import scala.collection.immutable
 import scala.util.{Failure, Success}
 
 trait InternController {
-  this: ExtractService with ConverterService with ArticleRepository with ArticleContentInformation with ExtractConvertStoreContent with SearchIndexService =>
+  this: ReadService with ExtractService with ConverterService with ArticleRepository with ArticleContentInformation
+    with ExtractConvertStoreContent with SearchIndexService =>
   val internController: InternController
 
   class InternController extends NdlaController {
@@ -60,5 +64,41 @@ trait InternController {
     get("/embedurls/:external_subject_id") {
       ArticleContentInformation.getExternalEmbedResources(params("external_subject_id"))
     }
+
+    get("/reports/headerElementsInLists") {
+      contentType = "text/csv"
+      logger.info("Start searching for header elements in Lists in all articles")
+      val start = System.currentTimeMillis()
+      var errorMessages: List[HtmlFaultRapport] = immutable.List()
+      articleRepository.getAllIds.map(m => {
+        val article = readService.withId(m.articleId)
+          article match {
+          case Some(art) => {
+            art.content.map(c => {
+
+              val listElements = stringToJsoupDocument(c.content).select("li")
+              val regex = """<h[1-4]>""".r
+
+              listElements.map(li => {
+                val allIn = regex.findAllIn(li.toString).toList
+
+                allIn.map(m => {
+                  val error = s"html element $m er ikke lov inni <li> elementer, se i: [$li]"
+                  errorMessages = HtmlFaultRapport(art.id, error) :: errorMessages
+                })
+              })
+            })
+
+          }
+          case None => logger.warn(s"Did not find article given id ${m.articleId} gotten from articleRepository.getAllIds, should be investigated if not due to race condition")
+        }
+      })
+      val stop = System.currentTimeMillis()
+      logger.info(s"Done searching for header elements in Lists time taken ${stop - start} ms. Found ${errorMessages.size} faults.")
+      //Change the list to CSV format with header row.
+      val em = (s"""artikkel id;feil funnet""" :: errorMessages.map(e => s"""${e.articleId};"${e.faultMessage}"""")).mkString("\n")
+      Ok(em)
+    }
   }
+
 }

--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -67,37 +67,7 @@ trait InternController {
 
     get("/reports/headerElementsInLists") {
       contentType = "text/csv"
-      logger.info("Start searching for header elements in Lists in all articles")
-      val start = System.currentTimeMillis()
-      var errorMessages: List[HtmlFaultRapport] = immutable.List()
-      articleRepository.getAllIds.map(m => {
-        val article = readService.withId(m.articleId)
-          article match {
-          case Some(art) => {
-            art.content.map(c => {
-
-              val listElements = stringToJsoupDocument(c.content).select("li")
-              val regex = """<h[1-4]>""".r
-
-              listElements.map(li => {
-                val allIn = regex.findAllIn(li.toString).toList
-
-                allIn.map(m => {
-                  val error = s"html element $m er ikke lov inni <li> elementer, se i: [$li]"
-                  errorMessages = HtmlFaultRapport(art.id, error) :: errorMessages
-                })
-              })
-            })
-
-          }
-          case None => logger.warn(s"Did not find article given id ${m.articleId} gotten from articleRepository.getAllIds, should be investigated if not due to race condition")
-        }
-      })
-      val stop = System.currentTimeMillis()
-      logger.info(s"Done searching for header elements in Lists time taken ${stop - start} ms. Found ${errorMessages.size} faults.")
-      //Change the list to CSV format with header row.
-      val em = (s"""artikkel id;feil funnet""" :: errorMessages.map(e => s"""${e.articleId};"${e.faultMessage}"""")).mkString("\n")
-      Ok(em)
+      ArticleContentInformation.getFaultyHtmlReport()
     }
   }
 

--- a/src/main/scala/no/ndla/articleapi/model/domain/HtmlFaultRapport.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/HtmlFaultRapport.scala
@@ -1,0 +1,3 @@
+package no.ndla.articleapi.model.domain
+
+case class HtmlFaultRapport(articleId: String, faultMessage: String)

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -57,7 +57,7 @@ trait ArticleRepository {
       }
     }
 
-    def   insertWithExternalIds(article: Article, externalId: String, externalSubjectId: Seq[String])(implicit session: DBSession = AutoSession): Long = {
+    def insertWithExternalIds(article: Article, externalId: String, externalSubjectId: Seq[String])(implicit session: DBSession = AutoSession): Long = {
       val startRevision = 1
       val dataObject = new PGobject()
       dataObject.setType("jsonb")

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -57,7 +57,7 @@ trait ArticleRepository {
       }
     }
 
-    def insertWithExternalIds(article: Article, externalId: String, externalSubjectId: Seq[String])(implicit session: DBSession = AutoSession): Long = {
+    def   insertWithExternalIds(article: Article, externalId: String, externalSubjectId: Seq[String])(implicit session: DBSession = AutoSession): Long = {
       val startRevision = 1
       val dataObject = new PGobject()
       dataObject.setType("jsonb")

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -67,6 +67,23 @@ object TestData {
     "fagstoff"
   )
 
+  val apiArticleWithHtmlFault = api.Article(
+    "1",
+    None,
+    1,
+    Seq(api.ArticleTitle("test", Option("en"))),
+    Seq(api.ArticleContent("<li><h3>Det er ikke lov å gjøre dette.</h3></li>", None, Option("en"))),
+    api.Copyright(api.License("publicdomain", None, None), "", Seq()),
+    Nil,
+    Nil,
+    Nil,
+    Nil,
+    Nil,
+    DateTime.now().minusDays(4).toDate,
+    DateTime.now().minusDays(2).toDate,
+    "fagstoff"
+  )
+
   val (nodeId, nodeId2) = ("1234", "4321")
   val sampleTitle = ArticleTitle("title", Some("en"))
   val sampleContent = LanguageContent(nodeId, nodeId, "sample content", "metadescription",  Some("en"))

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -72,7 +72,12 @@ object TestData {
     None,
     1,
     Seq(api.ArticleTitle("test", Option("en"))),
-    Seq(api.ArticleContent("<li><h3>Det er ikke lov å gjøre dette.</h3></li>", None, Option("en"))),
+    Seq(api.ArticleContent(
+      """<ul><li><h1>Det er ikke lov å gjøre dette.</h1> Tekst utenfor.</li><li>Dette er helt ok</li></ul>
+        |<ul><li><h2>Det er ikke lov å gjøre dette.</h2></li><li>Dette er helt ok</li></ul>
+        |<ol><li><h3>Det er ikke lov å gjøre dette.</h3></li><li>Dette er helt ok</li></ol>
+        |<ol><li><h4>Det er ikke lov å gjøre dette.</h4></li><li>Dette er helt ok</li></ol>
+      """.stripMargin, None, Option("en"))),
     api.Copyright(api.License("publicdomain", None, None), "", Seq()),
     Nil,
     Nil,

--- a/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
@@ -12,7 +12,6 @@ package no.ndla.articleapi.controller
 import java.util.Date
 
 import no.ndla.articleapi.model.domain._
-import no.ndla.articleapi.model.api.{Article => ApiArticle}
 import no.ndla.articleapi.{TestData, TestEnvironment, UnitSuite}
 import org.json4s.native.Serialization._
 import org.scalatra.test.scalatest.ScalatraFunSuite
@@ -65,10 +64,13 @@ class InternControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     when(articleRepository.getAllIds()).thenReturn(Seq(ArticleIds(1, None)))
     when(readService.withId(1L)).thenReturn(Some(TestData.apiArticleWithHtmlFault)) //thenReturn(Some(TestData.newArticle))
       get(s"/reports/headerElementsInLists"){
-
         status should equal(200)
+        //Very end of line sensitive, do not adjust code with your IDE!
         body should equal("""artikkel id;feil funnet
-1;"html element <h3> er ikke lov inni <li> elementer, se i: [<li><h3>Det er ikke lov å gjøre dette.</h3></li>]"""")
+1;"html element <h4>Det er ikke lov å gjøre dette.</h4> er ikke lov inni: [<li><h4>Det er ikke lov å gjøre dette.</h4></li>]"
+1;"html element <h3>Det er ikke lov å gjøre dette.</h3> er ikke lov inni: [<li><h3>Det er ikke lov å gjøre dette.</h3></li>]"
+1;"html element <h2>Det er ikke lov å gjøre dette.</h2> er ikke lov inni: [<li><h2>Det er ikke lov å gjøre dette.</h2></li>]"
+1;"html element <h1>Det er ikke lov å gjøre dette.</h1> er ikke lov inni: [<li><h1>Det er ikke lov å gjøre dette.</h1> Tekst utenfor.</li>]"""")
       }
   }
 

--- a/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
@@ -12,12 +12,15 @@ package no.ndla.articleapi.controller
 import java.util.Date
 
 import no.ndla.articleapi.model.domain._
-import no.ndla.articleapi.{TestEnvironment, UnitSuite}
+import no.ndla.articleapi.model.api.{Article => ApiArticle}
+import no.ndla.articleapi.{TestData, TestEnvironment, UnitSuite}
 import org.json4s.native.Serialization._
 import org.scalatra.test.scalatest.ScalatraFunSuite
 import org.mockito.Mockito._
+
 import scala.util.{Failure, Try}
 import no.ndla.articleapi.TestData._
+import org.mockito.Matchers.anyLong
 
 class InternControllerTest extends UnitSuite with TestEnvironment with ScalatraFunSuite {
   implicit val formats = org.json4s.DefaultFormats
@@ -54,6 +57,20 @@ class InternControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     post(s"/import/$nodeId") {
       status should equal(500)
     }
+  }
+
+  test("Test GET csv repport of illegal use of h tags in li elements") {
+
+    var test:Seq[ArticleIds] = Nil
+    when(articleRepository.getAllIds()).thenReturn(Seq(ArticleIds(1, None)))
+    when(readService.withId(1L)).thenReturn(Some(TestData.apiArticleWithHtmlFault)) //thenReturn(Some(TestData.newArticle))
+      get(s"/reports/headerElementsInLists"){
+
+        println(s"body: [$body]")
+        status should equal(200)
+        body should equal("""artikkel id;feil funnet
+1;"html element <h3> er ikke lov inni <li> elementer, se i: [<li><h3>Det er ikke lov å gjøre dette.</h3></li>]"""")
+      }
   }
 
 }

--- a/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
@@ -66,7 +66,6 @@ class InternControllerTest extends UnitSuite with TestEnvironment with ScalatraF
     when(readService.withId(1L)).thenReturn(Some(TestData.apiArticleWithHtmlFault)) //thenReturn(Some(TestData.newArticle))
       get(s"/reports/headerElementsInLists"){
 
-        println(s"body: [$body]")
         status should equal(200)
         body should equal("""artikkel id;feil funnet
 1;"html element <h3> er ikke lov inni <li> elementer, se i: [<li><h3>Det er ikke lov å gjøre dette.</h3></li>]"""")


### PR DESCRIPTION
 P.t. tar det 20 min (gitt dagens ca 15000 artikler kjørende i IntelliJ) før den terminerer, aka browsern står å jobber i 20 min på en blank skjerm før det kommer en csv fil. Bør være noe frontend spinnere el.l. i forkant hvis noen andre enn "oss" skal bruke det. 