### PR TITLE
Ndlano/issues#495 make sure content is wrapped in sections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val article_api = (project in file(".")).
       "org.apache.lucene" % "lucene-test-framework" % "6.4.1" % "test",
       "vc.inreach.aws" % "aws-signing-request-interceptor" % "0.0.16",
       "org.scalatest" %% "scalatest" % ScalaTestVersion % "test",
-      "org.jsoup" % "jsoup" % "1.7.3",
+      "org.jsoup" % "jsoup" % "1.10.3",
       "org.mockito" % "mockito-all" % MockitoVersion % "test",
       "org.flywaydb" % "flyway-core" % "4.0",
       "com.netaporter" %% "scala-uri" % "0.4.16"

--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -19,7 +19,7 @@ trait HTMLCleaner {
   val htmlCleaner: HTMLCleaner
 
   class HTMLCleaner extends ConverterModule with LazyLogging {
-    private def NBSP = "\u00a0" // \u00a0 is the unicode representation of &nbsp;
+    private def NBSP = "&#xa0;" // jsoup unicode representation of &nbsp;
 
     override def convert(content: LanguageContent, importStatus: ImportStatus): Try[(LanguageContent, ImportStatus)] = {
       val element = stringToJsoupDocument(content.content)

--- a/src/main/scala/no/ndla/articleapi/service/converters/MathMLConverter.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/MathMLConverter.scala
@@ -32,6 +32,5 @@ object MathMLConverter extends ConverterModule {
     el.select("math").asScala.foreach(e => e.attr(s"$XMLNsAttribute", "http://www.w3.org/1998/Math/MathML"))
   }
 
-  def replaceNbsp(el: Element) = el.html(el.html().replace("\u00a0", " "))
-
+  def replaceNbsp(el: Element) = el.html(el.html().replace("&#xa0;", " "))
 }

--- a/src/main/scala/no/ndla/articleapi/service/converters/MathMLConverter.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/MathMLConverter.scala
@@ -32,5 +32,5 @@ object MathMLConverter extends ConverterModule {
     el.select("math").asScala.foreach(e => e.attr(s"$XMLNsAttribute", "http://www.w3.org/1998/Math/MathML"))
   }
 
-  def replaceNbsp(el: Element) = el.html(el.html().replace("&#xa0;", " "))
+  def replaceNbsp(el: Element) = el.html(el.html().replace(NBSP, " "))
 }

--- a/src/main/scala/no/ndla/articleapi/service/converters/package.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/package.scala
@@ -1,0 +1,12 @@
+/*
+ * Part of NDLA article_api.
+ * Copyright (C) 2017 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.service
+
+package object converters {
+  val NBSP = "&#xa0;" // standard notation for &nbsp; used by jsoup
+}

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -154,7 +154,7 @@ object TestData {
     Option(1),
     Option(1),
     Seq(ArticleTitle("test", Option("en"))),
-    Seq(ArticleContent("<article><div>test</div></article>", None, Option("en"))),
+    Seq(ArticleContent("<section><div>test</div></section>", None, Option("en"))),
     publicDomainCopyright,
     Seq(),
     Seq(),
@@ -237,7 +237,7 @@ object TestData {
   val updatedArticle = api.UpdatedArticle(
     Seq(api.ArticleTitle("test", Option("en"))),
     1,
-    Seq(api.ArticleContent("<article><div>test</div></article>", None, Option("en"))),
+    Seq(api.ArticleContent("<section><div>test</div></section>", None, Option("en"))),
     Seq.empty,
     Seq.empty,
     Seq.empty,

--- a/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
@@ -92,14 +92,14 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("ingress is extracted when wrapped in <p> tags") {
     val content =
       s"""<section>
-        |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5359" data-align="" data-resource="image" data-alt="To personer" data-caption="capt." />
-        |<p><strong>Når man driver med medieproduksjon, er det mye arbeid som må gjøres<br /></strong></p>
+        |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5359" data-align="" data-resource="image" data-alt="To personer" data-caption="capt.">
+        |<p><strong>Når man driver med medieproduksjon, er det mye arbeid som må gjøres<br></strong></p>
         |</section>
         |<section> <p>Det som kan gi helse- og sikkerhetsproblemer på en dataarbeidsplass, er:</section>""".stripMargin.replace("\n", "")
     val expectedContentResult = ArticleContent(
       s"""<section>
-         |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5359" data-align="" data-resource="image" data-alt="To personer" data-caption="capt." />
-         |<p><strong>Når man driver med medieproduksjon, er det mye arbeid som må gjøres<br /></strong></p>
+         |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5359" data-align="" data-resource="image" data-alt="To personer" data-caption="capt.">
+         |<p><strong>Når man driver med medieproduksjon, er det mye arbeid som må gjøres<br></strong></p>
          |</section>
          |<section> <p>Det som kan gi helse- og sikkerhetsproblemer på en dataarbeidsplass, er:</p></section>""".stripMargin.replace("\n", ""), None, Some("nb"))
 
@@ -143,9 +143,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That html comments are removed") {
-    val contentNodeBokmal = sampleLanguageContent.copy(content="""<p><!-- this is a comment -->not a comment</p> <!-- another comment -->""")
+    val contentNodeBokmal = sampleLanguageContent.copy(content="""<p><!-- this is a comment -->not a comment</p><!-- another comment -->""")
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
-    val expectedResult = """<p>not a comment</p>"""
+    val expectedResult = "<p>not a comment</p>"
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
 
@@ -162,7 +162,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val imageMeta = ImageMetaInformation(newId, List(), List(), imageUrl, 256, "", ImageCopyright(ImageLicense("", "", Some("")), "", List()), List())
     val expectedResult =
       s"""|<article>
-          |<$resourceHtmlEmbedTag data-align="" data-alt="$sampleAlt" data-caption="" data-resource="image" data-resource_id="1" data-size="fullbredde" />
+          |<$resourceHtmlEmbedTag data-align="" data-alt="$sampleAlt" data-caption="" data-resource="image" data-resource_id="1" data-size="fullbredde">
           |</article>""".stripMargin.replace("\n", "")
 
     when(extractService.getNodeType(nodeId)).thenReturn(Some("image"))
@@ -189,7 +189,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("That empty html tags are removed") {
     val contentNodeBokmal = sampleLanguageContent.copy(content=s"""<article> <div></div><p><div></div></p><$resourceHtmlEmbedTag ></$resourceHtmlEmbedTag></article>""")
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
-    val expectedResult = s"""<article> <$resourceHtmlEmbedTag /></article>"""
+    val expectedResult = s"""<article> <$resourceHtmlEmbedTag></article>"""
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
 
@@ -236,7 +236,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("JoubelH5PConverter is used when ENABLE_JOUBEL_H5P_OEMBED is true") {
     val h5pNodeId = "160303"
     val contentStringWithValidNodeId = s"[contentbrowser ==nid=$h5pNodeId==imagecache=Fullbredde==width===alt=$sampleAlt==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion===link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
-    val expectedResult = s"""<$resourceHtmlEmbedTag data-resource="h5p" data-url="${JoubelH5PConverter.JoubelH5PBaseUrl}/1" />"""
+    val expectedResult = s"""<$resourceHtmlEmbedTag data-resource="h5p" data-url="${JoubelH5PConverter.JoubelH5PBaseUrl}/1">"""
 
     val contentNodeBokmal = sampleLanguageContent.copy(content=contentStringWithValidNodeId)
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
@@ -300,9 +300,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
 
   test("toDomainArticleShould should remove unneeded attributes on embed-tags") {
     val content = s"""<h1>hello</h1><embed ${Attributes.DataResource}="${ResourceType.Image}" ${Attributes.DataUrl}="http://some-url" ${Attributes.DataId}=1 data-random="hehe" />"""
-    val expectedContent = s"""<h1>hello</h1><embed ${Attributes.DataResource}="${ResourceType.Image}" />"""
+    val expectedContent = s"""<h1>hello</h1><embed ${Attributes.DataResource}="${ResourceType.Image}">"""
     val visualElement = s"""<embed ${Attributes.DataResource}="${ResourceType.Image}" ${Attributes.DataUrl}="http://some-url" ${Attributes.DataId}=1 data-random="hehe" />"""
-    val expectedVisualElement = s"""<embed ${Attributes.DataResource}="${ResourceType.Image}" />"""
+    val expectedVisualElement = s"""<embed ${Attributes.DataResource}="${ResourceType.Image}">"""
     val articleContent = api.ArticleContent(content, None, Some("en"))
     val articleVisualElement = api.VisualElement(visualElement, Some("en"))
     val apiArticle = TestData.newArticle.copy(content=Seq(articleContent), visualElement=Some(Seq(articleVisualElement)))

--- a/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
@@ -32,12 +32,12 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   val sampleNode = NodeToConvert(List(contentTitle), Seq(), "by-sa", Seq(author), List(tag), "fagstoff", "fagstoff", new Date(0), new Date(1), ArticleType.Standard)
   val sampleLanguageContent = TestData.sampleContent.copy(content=sampleContentString, language=Some("nb"))
 
-  test("That the document is wrapped in an article tag") {
+  test("That the document is wrapped in an section tag") {
     val nodeId = "1"
     val initialContent = "<h1>Heading</h1>"
     val contentNode = sampleLanguageContent.copy(content=initialContent)
     val node = sampleNode.copy(contents=List(contentNode))
-    val expedtedResult = initialContent
+    val expedtedResult = s"<section>$initialContent</section>"
 
     when(extractConvertStoreContent.processNode("4321")).thenReturn(Try(TestData.sampleArticleWithPublicDomain, ImportStatus(Seq(), Seq())))
 
@@ -62,7 +62,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     when(extractService.getNodeGeneralContent(nodeId2)).thenReturn(Seq(sampleOppgave2))
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
-    result.content.head.content should equal ("Innhold! Enda mer innhold!")
+    result.content.head.content should equal ("<section>Innhold! Enda mer innhold!</section>")
     status.messages.isEmpty should equal (true)
     result.requiredLibraries.isEmpty should equal (true)
   }
@@ -76,8 +76,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val contentNodeNynorsk = TestData.sampleContent.copy(content="Nordavinden og sola krangla ein gong om kven av dei som var den sterkaste", ingress=Some(ingressNodeNynorsk))
 
     val node = sampleNode.copy(contents=List(contentNodeBokmal, contentNodeNynorsk))
-    val bokmalExpectedResult = "Nordavinden og sola kranglet en gang om hvem av dem som var den sterkeste"
-    val nynorskExpectedResult = "Nordavinden og sola krangla ein gong om kven av dei som var den sterkaste"
+    val bokmalExpectedResult = "<section>Nordavinden og sola kranglet en gang om hvem av dem som var den sterkeste</section>"
+    val nynorskExpectedResult = "<section>Nordavinden og sola krangla ein gong om kven av dei som var den sterkaste</section>"
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
     val bokmalResult = result.content.head.content
@@ -118,9 +118,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That html attributes are removed from the article") {
-    val contentNodeBokmal = sampleLanguageContent.copy(content="""<table class="testclass" title="test"></table>""")
+    val contentNodeBokmal = sampleLanguageContent.copy(content="""<section><div class="testclass" title="test">high</div></section>""")
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
-    val bokmalExpectedResult = """<table></table>"""
+    val bokmalExpectedResult = """<section><div>high</div></section>"""
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
 
@@ -130,10 +130,10 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That align attributes for td tags are not removed") {
-    val htmlTableWithAlignAttributes = """<table><tbody><tr><td align="right" valign="top">Table row cell</td></tr></tbody></table>"""
+    val htmlTableWithAlignAttributes = """<section><table><tbody><tr><td align="right" valign="top">Table row cell</td></tr></tbody></table></section>"""
     val contentNodeBokmal = sampleLanguageContent.copy(content=htmlTableWithAlignAttributes)
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
-    val expectedResult = """<table><tbody><tr><th align="right" valign="top">Table row cell</th></tr></tbody></table>"""
+    val expectedResult = """<section><table><tbody><tr><th align="right" valign="top">Table row cell</th></tr></tbody></table></section>"""
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
 
@@ -143,9 +143,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That html comments are removed") {
-    val contentNodeBokmal = sampleLanguageContent.copy(content="""<p><!-- this is a comment -->not a comment</p><!-- another comment -->""")
+    val contentNodeBokmal = sampleLanguageContent.copy(content="""<section><p><!-- this is a comment -->not a comment</p><!-- another comment --></section>""")
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
-    val expectedResult = "<p>not a comment</p>"
+    val expectedResult = "<section><p>not a comment</p></section>"
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
 
@@ -157,13 +157,13 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("That images are converted") {
     val (nodeId, imageUrl, alt) = ("1234", "full.jpeg", "Fotografi")
     val newId = "1"
-    val contentNode = sampleLanguageContent.copy(content=s"<article>$sampleContentString</article>")
+    val contentNode = sampleLanguageContent.copy(content=s"<section>$sampleContentString</section>")
     val node = sampleNode.copy(contents=List(contentNode))
     val imageMeta = ImageMetaInformation(newId, List(), List(), imageUrl, 256, "", ImageCopyright(ImageLicense("", "", Some("")), "", List()), List())
     val expectedResult =
-      s"""|<article>
+      s"""|<section>
           |<$resourceHtmlEmbedTag data-align="" data-alt="$sampleAlt" data-caption="" data-resource="image" data-resource_id="1" data-size="fullbredde">
-          |</article>""".stripMargin.replace("\n", "")
+          |</section>""".stripMargin.replace("\n", "")
 
     when(extractService.getNodeType(nodeId)).thenReturn(Some("image"))
     when(imageApiClient.importOrGetMetaByExternId(nodeId)).thenReturn(Some(imageMeta))
@@ -174,9 +174,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("&nbsp is removed") {
-    val contentNodeBokmal = sampleLanguageContent.copy(content="""<article> <p>hello&nbsp; you</article>""")
+    val contentNodeBokmal = sampleLanguageContent.copy(content="""<section> <p>hello&nbsp; you</section>""")
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
-    val expectedResult = """<article> <p>hello you</p></article>"""
+    val expectedResult = """<section> <p>hello you</p></section>"""
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
     val strippedResult = " +".r.replaceAllIn(result.content.head.content.replace("\n", ""), " ")
@@ -187,9 +187,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That empty html tags are removed") {
-    val contentNodeBokmal = sampleLanguageContent.copy(content=s"""<article> <div></div><p><div></div></p><$resourceHtmlEmbedTag ></$resourceHtmlEmbedTag></article>""")
+    val contentNodeBokmal = sampleLanguageContent.copy(content=s"""<section> <div></div><p><div></div></p><$resourceHtmlEmbedTag ></$resourceHtmlEmbedTag></section>""")
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
-    val expectedResult = s"""<article> <$resourceHtmlEmbedTag></article>"""
+    val expectedResult = s"""<section> <$resourceHtmlEmbedTag></section>"""
 
     val Success((result: Article, status)) = service.toDomainArticle(node, ImportStatus(Seq(), Seq()))
 
@@ -223,8 +223,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("MathML elements are converted correctly") {
-    val originalContent = "<math><menclose notation=\"updiagonalstrike\"></menclose>\u00a0</math>"
-    val expectedContent = """<math xmlns="http://www.w3.org/1998/Math/MathML"><menclose notation="updiagonalstrike"></menclose> </math>"""
+    val originalContent = "<section><math><menclose notation=\"updiagonalstrike\"></menclose>\u00a0</math></section>"
+    val expectedContent = """<section><math xmlns="http://www.w3.org/1998/Math/MathML"><menclose notation="updiagonalstrike"></menclose> </math></section>"""
     val initialContent: LanguageContent = sampleLanguageContent.copy(content=originalContent)
     val node = sampleNode.copy(contents=List(initialContent))
 
@@ -236,7 +236,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("JoubelH5PConverter is used when ENABLE_JOUBEL_H5P_OEMBED is true") {
     val h5pNodeId = "160303"
     val contentStringWithValidNodeId = s"[contentbrowser ==nid=$h5pNodeId==imagecache=Fullbredde==width===alt=$sampleAlt==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion===link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
-    val expectedResult = s"""<$resourceHtmlEmbedTag data-resource="h5p" data-url="${JoubelH5PConverter.JoubelH5PBaseUrl}/1">"""
+    val expectedResult = s"""<section><$resourceHtmlEmbedTag data-resource="h5p" data-url="${JoubelH5PConverter.JoubelH5PBaseUrl}/1"></section>"""
 
     val contentNodeBokmal = sampleLanguageContent.copy(content=contentStringWithValidNodeId)
     val node = sampleNode.copy(contents=List(contentNodeBokmal))
@@ -323,9 +323,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("That divs with class 'ndla_table' is converted to table") {
-    val sampleLanguageContent: LanguageContent = TestData.sampleContent.copy(content="<article><div class=\"ndla_table another_class\">nobody builds walls better than me, believe me</div></article>")
+    val sampleLanguageContent: LanguageContent = TestData.sampleContent.copy(content="<section><div class=\"ndla_table another_class\">nobody builds walls better than me, believe me</div></section>")
     val node = sampleNode.copy(contents=List(sampleLanguageContent))
-    val expectedResult = "<article><table>nobody builds walls better than me, believe me</table></article>"
+    val expectedResult = "<section><table>nobody builds walls better than me, believe me</table></section>"
     val result = service.toDomainArticle(node, ImportStatus.empty)
     result.isSuccess should be (true)
 

--- a/src/test/scala/no/ndla/articleapi/service/HtmlTagsUsageTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/HtmlTagsUsageTest.scala
@@ -18,14 +18,15 @@ import no.ndla.articleapi.TestData
 class HtmlTagsUsageTest extends UnitSuite with TestEnvironment {
   val embedUrl = "http://hello.yes.this.is.dog"
   val copyright = Copyright("publicdomain", "", List())
-  val article1 = TestData.sampleArticleWithPublicDomain
+
+  val article1 = TestData.sampleArticleWithPublicDomain.copy(id=Option(1), content=Seq(ArticleContent("<section><div>test</div></section>", None, Option("en"))))
   val article2 = TestData.sampleArticleWithPublicDomain.copy(id=Option(2), content=Seq(ArticleContent("<article><div>test</div><p>paragraph</p></article>", None, Some("en"))))
   val article3 = TestData.sampleArticleWithPublicDomain.copy(id=Option(3), content=Seq(ArticleContent("<article><img></img></article>", None, Some("en"))))
   val article4 = TestData.sampleArticleWithPublicDomain.copy(id=Option(4), content=Seq(ArticleContent(s"""<article><$resourceHtmlEmbedTag data-resource="external" data-url="$embedUrl"" /></article>""", None, Some("en"))))
 
 
   test("That getHtmlTagsMap counts html elements correctly") {
-    val expectedResult = Map("article" -> List(1, 2, 3), "div" -> List(1, 2), "p" -> List(2), "img" -> List(3))
+    val expectedResult = Map("section" -> List(1), "article" -> List(2, 3), "div" -> List(1, 2), "p" -> List(2), "img" -> List(3))
     when(articleRepository.all).thenReturn(List(article1, article2, article3))
     ArticleContentInformation.getHtmlTagsMap should equal (expectedResult)
   }

--- a/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
@@ -26,11 +26,11 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   val imageType = s"${ResourceType.Image}"
   val h5pType = s"${ResourceType.H5P}"
   val urlAttr = s"${Attributes.DataUrl}"
-  val content1 = s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType" /><$resourceHtmlEmbedTag $resourceIdAttr=1234 $resourceAttr="$imageType" />"""
-  val content2 = s"""<$resourceHtmlEmbedTag $resourceIdAttr="321" $resourceAttr="$imageType" /><$resourceHtmlEmbedTag $resourceIdAttr=4321 $resourceAttr="$imageType" />"""
+  val content1 = s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType"><$resourceHtmlEmbedTag $resourceIdAttr=1234 $resourceAttr="$imageType">"""
+  val content2 = s"""<$resourceHtmlEmbedTag $resourceIdAttr="321" $resourceAttr="$imageType"><$resourceHtmlEmbedTag $resourceIdAttr=4321 $resourceAttr="$imageType">"""
   val articleContent1 = ArticleContent(content1, None, None)
   val expectedArticleContent1 = articleContent1.copy(content=
-    s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType" $idAttr="0" $urlAttr="$externalImageApiUrl/123" /><$resourceHtmlEmbedTag $resourceIdAttr="1234" $resourceAttr="$imageType" $idAttr="1" $urlAttr="$externalImageApiUrl/1234" />""")
+    s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType" $idAttr="0" $urlAttr="$externalImageApiUrl/123"><$resourceHtmlEmbedTag $resourceIdAttr="1234" $resourceAttr="$imageType" $idAttr="1" $urlAttr="$externalImageApiUrl/1234">""")
 
   val articleContent2 = ArticleContent(content2, None, None)
 
@@ -42,8 +42,8 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   override val converterService = new ConverterService
 
   test("withId adds urls and ids on embed resources") {
-    val visualElementBefore = s"""<$resourceHtmlEmbedTag data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />"""
-    val visualElementAfter = s"""<$resourceHtmlEmbedTag data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" data-id="0" data-url="http://proxy.ndla-local/image-api/v1/images/1" />"""
+    val visualElementBefore = s"""<$resourceHtmlEmbedTag data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="">"""
+    val visualElementAfter = s"""<$resourceHtmlEmbedTag data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" data-id="0" data-url="http://proxy.ndla-local/image-api/v1/images/1">"""
     val article = TestData.sampleArticleWithByNcSa.copy(content=Seq(articleContent1), visualElement=Seq(VisualElement(visualElementBefore, Some("nb"))))
 
     when(articleRepository.withId(1)).thenReturn(Option(article))
@@ -58,16 +58,16 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("addIdAndUrlOnResource adds id but not url on embed resources without a data-resource_id attribute") {
-    val articleContent3 = articleContent1.copy(content=s"""<$resourceHtmlEmbedTag $resourceAttr="$h5pType" $idAttr="0" $urlAttr="http://some.h5p.org" />""")
+    val articleContent3 = articleContent1.copy(content=s"""<$resourceHtmlEmbedTag $resourceAttr="$h5pType" $idAttr="0" $urlAttr="http://some.h5p.org">""")
     readService.addIdAndUrlOnResource(articleContent3.content) should equal(articleContent3.content)
   }
 
   test("addIdAndUrlOnResource adds urls on all content translations in an article") {
     val article = TestData.sampleArticleWithByNcSa.copy(content=Seq(articleContent1, articleContent2))
     val article1ExpectedResult = articleContent1.copy(content=
-      s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType" $idAttr="0" $urlAttr="$externalImageApiUrl/123" /><$resourceHtmlEmbedTag $resourceIdAttr="1234" $resourceAttr="$imageType" $idAttr="1" $urlAttr="$externalImageApiUrl/1234" />""")
+      s"""<$resourceHtmlEmbedTag $resourceIdAttr="123" $resourceAttr="$imageType" $idAttr="0" $urlAttr="$externalImageApiUrl/123"><$resourceHtmlEmbedTag $resourceIdAttr="1234" $resourceAttr="$imageType" $idAttr="1" $urlAttr="$externalImageApiUrl/1234">""")
     val article2ExpectedResult = articleContent1.copy(content=
-      s"""<$resourceHtmlEmbedTag $resourceIdAttr="321" $resourceAttr="$imageType" $idAttr="0" $urlAttr="$externalImageApiUrl/321" /><$resourceHtmlEmbedTag $resourceIdAttr="4321" $resourceAttr="$imageType" $idAttr="1" $urlAttr="$externalImageApiUrl/4321" />""")
+      s"""<$resourceHtmlEmbedTag $resourceIdAttr="321" $resourceAttr="$imageType" $idAttr="0" $urlAttr="$externalImageApiUrl/321"><$resourceHtmlEmbedTag $resourceIdAttr="4321" $resourceAttr="$imageType" $idAttr="1" $urlAttr="$externalImageApiUrl/4321">""")
 
     val result = readService.addUrlsAndIdsOnEmbedResources(article)
     result should equal (article.copy(content=Seq(article1ExpectedResult, article2ExpectedResult)))

--- a/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
@@ -61,7 +61,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("ingress is extracted when wrapped in <p> tags") {
     val content = s"""<section>
-                   |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                   |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                    |<p><strong>Medievanene er i endring.</br></strong></p>
                    |</section>
                    |<section>
@@ -70,7 +70,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
     val expectedContentResult =
       s"""<section>
-         |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+         |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
          |</section>
          |<section>
          |<h2>Mediehverdagen</h2>
@@ -85,12 +85,12 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("ingress text is not extracted when not present") {
     val content = s"""<section>
-                    |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                    |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                     |<h2>Mediehverdagen</h2>
                     |</section>""".stripMargin.replace("\n", "")
     val expectedContentResult =
       s"""<section>
-         |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+         |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
          |<h2>Mediehverdagen</h2>
          |</section>""".stripMargin.replace("\n", "")
     val expectedIngressResult = None
@@ -103,8 +103,8 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("ingress with word count less than 3 should not be interpreted as an ingress") {
     val content = s"""<section>
-                     |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
-                     |<p><strong>Medievanener<br /></strong></p>
+                     |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
+                     |<p><strong>Medievanener<br></strong></p>
                      |</section>
                      |<section>
                      |<h2>Mediehverdagen</h2>
@@ -124,7 +124,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
           |<li><a href="#" title="Snopes">Snopes</a></li>
           |</ul>
         |</section>
-      """.stripMargin.replace("\n", "")
+      |""".stripMargin.replace("\n", "")
     val expectedContentResult = """<section><ul><li><a href="#" title="Snopes">Snopes</a></li></ul></section>"""
     val expectedIngressResult = LanguageIngress("Du har sikkert opplevd rykter og usannheter", TestData.sampleContent.language)
     val Success((result, _)) = htmlCleaner.convert(TestData.sampleContent.copy(content=content), defaultImportStatus)
@@ -135,13 +135,13 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("ingress text is extracted when wrapped in <strong> tags") {
     val content = s"""<section>
-                    |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                    |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                     |<strong>Medievanene er i endring.</strong>
                     |<h2>Mediehverdagen</h2>
                     |</section>""".stripMargin.replace("\n", "")
     val expectedContentResult =
       s"""<section>
-        |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+        |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
         |<h2>Mediehverdagen</h2></section>""".stripMargin.replace("\n", "")
     val expectedIngressResult = LanguageIngress("Medievanene er i endring.", TestData.sampleContent.language)
     val Success((result, _)) = htmlCleaner.convert(TestData.sampleContent.copy(content=content), defaultImportStatus)
@@ -152,7 +152,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("ingress should not be extracted if not located in the beginning of content") {
     val content = s"""<section>
-                     |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                     |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                      |<h2>Mediehverdagen</h2>
                      |<p>A paragraph!</p>
                      |<p><strong>Medievanene er i endring.</strong><p>
@@ -169,7 +169,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
          |</strong></p>
          |<h2>Tips til aktuelle verktøy og bruk av verktøy</h2>
          |</section>""".stripMargin
-    val expectedContentResult = s"""<section><embed data-align="" data-alt="Hånd som tegner" data-caption="" data-resource="image" data-resource_id="200" data-size="fullbredde" />
+    val expectedContentResult = s"""<section><embed data-align="" data-alt="Hånd som tegner" data-caption="" data-resource="image" data-resource_id="200" data-size="fullbredde">
 
       |<h2>Tips til aktuelle verktøy og bruk av verktøy</h2>
       |</section>""".stripMargin
@@ -182,15 +182,15 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   }
 
   test("ingress inside a div should be extracted") {
+    val nbsp = "\u00a0"
     val content =
-      """<section><div>
-        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla" />
-        |<p><strong> </strong><strong>Du er et unikt individ, med en rekke personlige egenskaper.</strong></p>
-        |</div></section>
-      """.stripMargin
+      s"""<section><div>
+        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla">
+        |<p><strong>$nbsp</strong><strong>Du er et unikt individ, med en rekke personlige egenskaper.</strong></p>
+        |</div></section>""".stripMargin
     val expectedContent =
       """<section><div>
-        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla" />
+        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla">
         |
         |</div></section>""".stripMargin
     val expectedIngress = Some(LanguageIngress("Du er et unikt individ, med en rekke personlige egenskaper.", TestData.sampleContent.language))
@@ -204,12 +204,12 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   test("ingress inside a nested div should be extracted") {
     val content =
       """<section><div><div>
-        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla" />
+        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla">
         |<p><strong>Du er et unikt individ, med en rekke personlige egenskaper.</strong></p>
         |</div><p>do not touch</p></div></section>""".stripMargin
     val expectedContent =
       """<section><div><div>
-        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla" />
+        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla">
         |
         |</div><p>do not touch</p></div></section>""".stripMargin
     val expectedIngress = Some(LanguageIngress("Du er et unikt individ, med en rekke personlige egenskaper.", TestData.sampleContent.language))
@@ -223,12 +223,12 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   test("ingres inside first paragraph should be extracted when also div is present") {
     val content =
       """<section><p><strong>correct ingress more than three words</strong></p><div><div>
-        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla" />
+        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla">
         |<p><strong>Du er et unikt individ, med en rekke personlige egenskaper.</strong></p>
         |</div><p>do not touch</p></div></section>""".stripMargin
     val expectedContent =
       """<section><div><div>
-        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla" />
+        |<embed data-align="" data-alt="To gutter" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" data-id="0" data-url="http://ndla">
         |<p><strong>Du er et unikt individ, med en rekke personlige egenskaper.</strong></p>
         |</div><p>do not touch</p></div></section>""".stripMargin
     val expectedIngress = Some(LanguageIngress("correct ingress more than three words", TestData.sampleContent.language))
@@ -281,12 +281,12 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("That HTMLCleaner do not insert ingress if already added from seperate table") {
     val content = s"""<section>
-                      |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                      |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                       |<strong>Medievanene er i endring.</strong>
                       |<h2>Mediehverdagen</h2>
                       |</section>""".stripMargin.replace("\n", "")
     val expectedContentResult = s"""<section>
-          |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+          |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
           |<strong>Medievanene er i endring.</strong>
           |<h2>Mediehverdagen</h2>
           |</section>""".stripMargin.replace("\n", "")
@@ -304,12 +304,12 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("That HTMLCleaner removes all tags in ingress from seperate table") {
     val content = s"""<section>
-                      |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                      |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                       |<strong>Medievanene er i endring.</strong>
                       |<h2>Mediehverdagen</h2>
                       |</section>""".stripMargin.replace("\n", "")
     val expectedContentResult = s"""<section>
-                                    |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                                    |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                                     |<strong>Medievanene er i endring.</strong>
                                     |<h2>Mediehverdagen</h2>
                                     |</section>""".stripMargin.replace("\n", "")
@@ -324,13 +324,13 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
   test("HTMLCleaner extracts two first string paragraphs as ingress") {
     val content = s"""<section>
-                     |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                     |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                      |<p><strong>Medievanene er i endring.</strong></p>
                      |<p><strong>Er egentlig medievanene i endring</strong></p>
                      |<h2>Mediehverdagen</h2>
                      |</section>""".stripMargin.replace("\n", "")
     val expectedContentResult = s"""<section>
-                                   |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS" />
+                                   |<$resourceHtmlEmbedTag data-size="fullbredde" data-url="http://image-api/images/5452" data-align="" data-id="1" data-resource="image" data-alt="Mobiltelefon sender SMS">
                                    |<h2>Mediehverdagen</h2>
                                    |</section>""".stripMargin.replace("\n", "")
 
@@ -343,14 +343,14 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   }
 
   test("elements are replaced with data-caption text in meta description") {
-    val content = TestData.sampleContent.copy(content="", metaDescription=s"""Look at this image <$resourceHtmlEmbedTag data-resource="image" data-caption="image caption" />""")
+    val content = TestData.sampleContent.copy(content="", metaDescription=s"""Look at this image <$resourceHtmlEmbedTag data-resource="image" data-caption="image caption">""")
     val Success((result, _)) = htmlCleaner.convert(content, defaultImportStatus)
 
     result.metaDescription should equal ("Look at this image image caption")
   }
 
   test("an embed-image as the first element inside p tags are moved out of p tag") {
-    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img.jpg" />"""
+    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img.jpg">"""
     val content = TestData.sampleContent.copy(content=s"""<section><p>${image1}sample text</p></section>""")
 
     val expectedResult = s"""<section>$image1<p>sample text</p></section>"""
@@ -359,16 +359,16 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   }
 
   test("an embed-image inside p tags are moved out of p tag") {
-    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img.jpg" />"""
-    val content = TestData.sampleContent.copy(content=s"""<section><p><br />${image1}sample text</p></section>""")
+    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img.jpg">"""
+    val content = TestData.sampleContent.copy(content=s"""<section><p><br>${image1}sample text</p></section>""")
 
-    val expectedResult = s"""<section>$image1<p><br />sample text</p></section>"""
+    val expectedResult = s"""<section>$image1<p><br>sample text</p></section>"""
     val Success((result, _)) = htmlCleaner.convert(content, defaultImportStatus)
     result.content should equal (expectedResult)
   }
 
   test("an embed-image inside p tags with br are moved out of p tag and p tag is removed") {
-    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img.jpg" />"""
+    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img.jpg">"""
     val content = TestData.sampleContent.copy(content=s"""<section><p><br />$image1</p></section>""")
 
     val expectedResult = s"""<section>$image1</section>"""
@@ -377,9 +377,9 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   }
 
   test("embed-images inside p tags are moved out of p tag and p is removed if empty") {
-    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img1.jpg" />"""
-    val image2 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img2.jpg" />"""
-    val image3 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img3.jpg" />"""
+    val image1 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img1.jpg">"""
+    val image2 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img2.jpg">"""
+    val image3 = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img3.jpg">"""
     val content = TestData.sampleContent.copy(content=s"""<section><p>$image1$image2 $image3</p></section>""")
 
     val expectedResult = s"""<section>$image1$image2$image3</section>"""
@@ -388,7 +388,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   }
 
   test("embed-images inside nested p tags are moved out of p tag and p is removed if empty") {
-    val image = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img1.jpg" />"""
+    val image = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img1.jpg">"""
     val content = TestData.sampleContent.copy(content=s"""<section><p><strong>$image</strong></p></section>""")
 
     val expectedResult = s"""<section>$image</section>"""
@@ -405,7 +405,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   }
 
   test("moveMisplacedAsideTags should move aside tags located at the start of the article further down") {
-    val image = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img1.jpg" />"""
+    val image = s"""<$resourceHtmlEmbedTag data-resource="image" data-url="http://some.url.org/img1.jpg">"""
     val paragraph = "<p>sample text</p>"
     val aside = "<aside>This block should not be on top</aside>"
 
@@ -423,6 +423,15 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
     val expectedContent3 = s"""<section>$aside</section>"""
     val Success((result3, _)) = htmlCleaner.convert(TestData.sampleContent.copy(content=originalContent3), defaultImportStatus)
     result3.content should equal (expectedContent3)
+  }
+
+  test("all content must be wrapped in sections") {
+    val original = "<h1>hello</h1><p>content</p>"
+    val content = TestData.sampleContent.copy(content=original)
+    val expected = s"<section>$original</section>"
+
+    val Success((result, _)) = htmlCleaner.convert(content, defaultImportStatus)
+//    result.content should equal(expected)
   }
 
 }

--- a/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
@@ -460,6 +460,35 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
     result.content should equal(expected)
   }
 
+  test("an empty section should be inserted as the first element if first element is not a section") {
+    val original =
+      "<h1>hello</h1>" +
+      "<section>" +
+        "<p>here, have a content</p>" +
+      "</section>" +
+      "<p>you deserve it</p>" +
+      "<section>" +
+        "<p>outro</p>" +
+      "</section>"
+    val content = TestData.sampleContent.copy(content=original)
+    val expected =
+      "<section>" +
+        "<h1>hello</h1>" +
+      "</section>" +
+      "<section>" +
+        "<p>here, have a content</p>" +
+        "<p>you deserve it</p>" +
+      "</section>" +
+      "<section>" +
+        "<p>outro</p>" +
+      "</section>"
+
+
+    val Success((result, _)) = htmlCleaner.convert(content, defaultImportStatus)
+
+    result.content should equal(expected)
+  }
+
   test("an empty document should not be wrapped in a section") {
     val original = ""
     val content = TestData.sampleContent.copy(content=original)

--- a/src/test/scala/no/ndla/articleapi/service/converters/SimpleTagConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/SimpleTagConverterTest.scala
@@ -65,11 +65,11 @@ class SimpleTagConverterTest extends UnitSuite {
 
   test("That divs with class 'hide' converted to details-summary tags") {
     val initialContent = TestData.sampleContent.copy(content="""<div class="hide">Eksempel: <a href="#" class="read-more">les mer</a>
-      <div class="details">
-        <p>Hello, this is content</p>
-        <a class="re-collapse" href="#">skjul</a>
-      </div>
-    </div>""")
+      |<div class="details">
+        |<p>Hello, this is content</p>
+        |<a class="re-collapse" href="#">skjul</a>
+      |</div>
+    |</div>""".stripMargin.replace("\n", ""))
     val expectedResult = "<details><summary>Eksempel: les mer</summary><p>Hello, this is content</p></details>"
     val Success((result, _)) = SimpleTagConverter.convert(initialContent, ImportStatus(Seq(), Seq()))
 

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/ContentBrowserConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/ContentBrowserConverterTest.scala
@@ -34,7 +34,7 @@ class ContentBrowserConverterTest extends UnitSuite with TestEnvironment {
     val (validNodeId, joubelH5PIdId) = ValidH5PNodeIds.head
     val sampleContentString = s"[contentbrowser ==nid=$validNodeId==imagecache=Fullbredde==width===alt=$sampleAlt==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=inline==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val initialContent = sampleContent.copy(content=s"<article>$sampleContentString</article>")
-    val expectedResult = s"""<article><$resourceHtmlEmbedTag data-resource="h5p" data-url="${JoubelH5PConverter.JoubelH5PBaseUrl}/$joubelH5PIdId" /></article>"""
+    val expectedResult = s"""<article><$resourceHtmlEmbedTag data-resource="h5p" data-url="${JoubelH5PConverter.JoubelH5PBaseUrl}/$joubelH5PIdId"></article>"""
 
     when(extractService.getNodeType(validNodeId)).thenReturn(Some("h5p_content"))
     val Success((result, _)) = contentBrowserConverter.convert(initialContent, ImportStatus(Seq(), Seq()))
@@ -49,7 +49,7 @@ class ContentBrowserConverterTest extends UnitSuite with TestEnvironment {
     val imageMeta = ImageMetaInformation(newId, List(), List(), imageUrl, 256, "", ImageCopyright(ImageLicense("", "", Some("")), "", List()), List())
     val expectedResult =
       s"""|<article>
-          |<$resourceHtmlEmbedTag data-align="" data-alt="$alt" data-caption="" data-resource="image" data-resource_id="1" data-size="fullbredde" />
+          |<$resourceHtmlEmbedTag data-align="" data-alt="$alt" data-caption="" data-resource="image" data-resource_id="1" data-size="fullbredde">
           |</article>""".stripMargin.replace("\n", "")
 
     when(extractService.getNodeType(nodeId)).thenReturn(Some("image"))
@@ -113,7 +113,7 @@ class ContentBrowserConverterTest extends UnitSuite with TestEnvironment {
   }
 
   test("That Content-browser strings of type video are converted into HTML img tags") {
-    val expectedResult = s"""<article><$resourceHtmlEmbedTag data-account="$NDLABrightcoveAccountId" data-caption="" data-player="$NDLABrightcovePlayerId" data-resource="brightcove" data-videoid="ref:$nodeId" /></article>"""
+    val expectedResult = s"""<article><$resourceHtmlEmbedTag data-account="$NDLABrightcoveAccountId" data-caption="" data-player="$NDLABrightcovePlayerId" data-resource="brightcove" data-videoid="ref:$nodeId"></article>"""
     when(extractService.getNodeType(nodeId)).thenReturn(Some("video"))
     val Success((result, _)) = contentBrowserConverter.convert(sampleContent, ImportStatus(Seq(), Seq()))
     val strippedResult = " +".r.replaceAllIn(result.content.replace("\n", ""), " ")


### PR DESCRIPTION
Under konvertering vil alt innhold som ikke er en del av en seksjon bli flyttet oppover til nermeste seksjon:
```html
<section>
  <h1>Title</h1>
</section>
<p>Content</p>
<section>
<p>outro</p>
</section>
```
Vil bli konvertert til dette:
```html
<section>
  <h1>Title</h1>
  <p>Content</p>
</section>
<section>
<p>outro</p>
</section>
```

Det er også lagt inn validering slik at alle artikler som opprettes må følge samme format.
Tok også jobben med å oppgradere Jsoup til siste versjon. Det medfører at `embed`, `br`, ... -tags ikke ender med en `/>` men bare `>`: Før: `<br />`, nå: `<br>`.