### PR TITLE
Ndlano/issues#528 alphanumeric lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ The embed tag contains a set of attributes which define what content should be i
 * **data-nrk-video-id** - an ID to nrk videos. Present in nrk
 * **data-resource_id** - an ID to an internal resource to be inserted. Present in image and audio
 
+### Other tags with extra attributes
+The following tags may contain extra attributes which conveys information about how they should be displayed
+* `ol`
+  * **data-type** - If present and with the value "alphanum" the bullets should be alphanumeric
+
 ## Developer documentation
 
 **Compile**: sbt compile

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The embed tag contains a set of attributes which define what content should be i
 ### Other tags with extra attributes
 The following tags may contain extra attributes which conveys information about how they should be displayed
 * `ol`
-  * **data-type** - If present and with the value "alphanum" the bullets should be alphanumeric
+  * **data-type** - If present and with the value "letters" the bullets should be letters.
 
 ## Developer documentation
 

--- a/src/main/resources/html-rules.json
+++ b/src/main/resources/html-rules.json
@@ -34,6 +34,9 @@
       "href",
       "title",
       "name"
+    ],
+    "ol": [
+      "data-type"
     ]
   },
   "tags": [
@@ -64,7 +67,6 @@
     "strong",
     "embed",
     "a",
-    "ol",
     "i",
     "u",
     "button",

--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -259,7 +259,7 @@ trait HTMLCleaner {
       element.select("ol").asScala.foreach(x => {
         val styling = x.attr("style").split(";")
         if (styling.contains("list-style-type: lower-alpha")) {
-          x.attr(Attributes.DataType.toString, "alphanum")
+          x.attr(Attributes.DataType.toString, "letters")
         }
       })
     }

--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -22,6 +22,7 @@ trait HTMLCleaner {
     override def convert(content: LanguageContent, importStatus: ImportStatus): Try[(LanguageContent, ImportStatus)] = {
       val element = stringToJsoupDocument(content.content)
       val illegalTags = unwrapIllegalTags(element).map(x => s"Illegal tag(s) removed: $x").distinct
+      convertLists(element)
       val illegalAttributes = removeAttributes(element).map(x => s"Illegal attribute(s) removed: $x").distinct
 
       moveImagesOutOfPTags(element)
@@ -252,6 +253,15 @@ trait HTMLCleaner {
         case _ =>
       }
       element
+    }
+
+    private def convertLists(element: Element) = {
+      element.select("ol").asScala.foreach(x => {
+        val styling = x.attr("style").split(";")
+        if (styling.contains("list-style-type: lower-alpha")) {
+          x.attr(Attributes.DataType.toString, "alphanum")
+        }
+      })
     }
 
   }

--- a/src/main/scala/no/ndla/articleapi/service/converters/HtmlTagGenerator.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HtmlTagGenerator.scala
@@ -144,6 +144,8 @@ object Attributes extends Enumeration {
   val Align = Value("align")
   val Valign = Value("valign")
 
+  val DataType = Value("data-type")
+
   def all: Set[String] = Attributes.values.map(_.toString)
 
   def valueOf(s: String): Option[Attributes.Value] = {

--- a/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
@@ -14,10 +14,10 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   val defaultLanguageIngress = LanguageIngress("Jeg er en ingress", None)
   val defaultLanguageIngressWithHtml = LanguageIngress("<p>Jeg er en ingress</p>", None)
 
-  test("embed tag should be an allowed tag") {
+  test("embed tag should be an allowed tag and contain data attributes") {
     HTMLCleaner.isTagValid("embed")
 
-    val dataAttrs = Attributes.values.map(_.toString).filter(x => x.startsWith("data-")).toSet
+    val dataAttrs = Attributes.values.map(_.toString).filter(x => x.startsWith("data-") && x != Attributes.DataType.toString)
     val legalEmbedAttrs = HTMLCleaner.legalAttributesForTag("embed")
 
     dataAttrs.foreach(x => legalEmbedAttrs should contain(x))
@@ -508,6 +508,25 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
 
     result.content should equal(expectedContent)
     result.ingress should equal(Some(LanguageIngress(expectedIngress, Some("en"))))
+  }
+
+  test("lists with alphanumeric bullets points should be properly converted") {
+    val originalContent =
+      """<section>
+        |<ol style="list-style-type: lower-alpha;">
+        |<li>Definer makt</li>
+        |</ol>
+        |</section>""".stripMargin
+    val expectedContent =
+      s"""<section>
+         |<ol ${Attributes.DataType}="alphanum">
+         |<li>Definer makt</li>
+         |</ol>
+         |</section>""".stripMargin
+
+    val Success((result, _))  = htmlCleaner.convert(TestData.sampleContent.copy(content=originalContent), defaultImportStatus)
+
+    result.content should equal(expectedContent)
   }
 
 }

--- a/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
@@ -519,7 +519,7 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
         |</section>""".stripMargin
     val expectedContent =
       s"""<section>
-         |<ol ${Attributes.DataType}="alphanum">
+         |<ol ${Attributes.DataType}="letters">
          |<li>Definer makt</li>
          |</ol>
          |</section>""".stripMargin


### PR DESCRIPTION
Legger til et attributt `data-type="alphanum"` på `ol` tagger som skal vises frem som bokstav-lister.

Tenker at `data-type`  også kan gjenbrukes på andre tagger som trenger mere infomasjon for hvordan de skal vises frem (f.ex aside tags som enten er høyrekolonne eller faktaboks).

Er åpen for et bedre navn enn `data-type` (@oyvinmar @chrpeter @sebastianjg @runesto)