### PR TITLE
open in new tab if link was lightbox

### DIFF
--- a/src/main/resources/html-rules.json
+++ b/src/main/resources/html-rules.json
@@ -14,7 +14,9 @@
     "a": [
       "href",
       "title",
-      "name"
+      "name",
+      "target",
+      "rel"
     ],
     "ol": [
       "data-type"

--- a/src/main/scala/no/ndla/articleapi/service/converters/HtmlTagGenerator.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HtmlTagGenerator.scala
@@ -120,8 +120,12 @@ trait HtmlTagGenerator {
       s"<details><summary>$linkText</summary>$content</details>"
     }
 
-    def buildAnchor(href: String, anchorText: String, title: String): String = {
-      val attributes = Map(Attributes.Href -> href, Attributes.Title -> title)
+    def buildAnchor(href: String, anchorText: String, title: String, openInNewTab: Boolean): String = {
+      val target = openInNewTab match {
+        case true => Map(Attributes.Target -> "_blank", Attributes.Rel -> "noopener noreferrer")
+        case false => Map[Attributes.Value, String]()
+      }
+      val attributes = Map(Attributes.Href -> href, Attributes.Title -> title) ++ target
       s"<a ${buildAttributesString(attributes)}>$anchorText</a>"
     }
 
@@ -184,6 +188,8 @@ object Attributes extends Enumeration {
   val Title = Value("title")
   val Align = Value("align")
   val Valign = Value("valign")
+  val Target = Value("target")
+  val Rel = Value("rel")
 
   val DataType = Value("data-type")
 

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/FilConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/FilConverterModule.scala
@@ -28,7 +28,7 @@ trait FilConverterModule {
       val importedFile = for {
         fileMeta <- extractService.getNodeFilMeta(nodeId)
         filePath <- attachmentStorageService.uploadFileFromUrl(nodeId, fileMeta)
-      } yield (HtmlTagGenerator.buildAnchor(s"$Domain/files/$filePath", fileMeta.fileName, fileMeta.fileName), Seq.empty, ImportStatus(Seq.empty, visitedNodes))
+      } yield (HtmlTagGenerator.buildAnchor(s"$Domain/files/$filePath", fileMeta.fileName, fileMeta.fileName, openInNewTab=false), Seq.empty, ImportStatus(Seq.empty, visitedNodes))
 
       importedFile match {
         case Success(x) => Success(x)

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterModule.scala
@@ -29,8 +29,7 @@ trait LenkeConverterModule {
       logger.info(s"Converting lenke with nid ${content.get("nid")}")
 
       convertLink(content) match {
-        case Success((linkHtml, requiredLibraries, errors)) =>
-          Success(linkHtml, requiredLibraries, ImportStatus(errors, visitedNodes))
+        case Success((linkHtml, requiredLibraries, errors)) => Success(linkHtml, requiredLibraries, ImportStatus(errors, visitedNodes))
         case Failure(x) => Failure(x)
       }
     }
@@ -42,7 +41,7 @@ trait LenkeConverterModule {
           case "link" => insertAnchor(url, cont)
           case "inline" => insertInline(url, embedCode, cont)
           case "lightbox_large" => insertAnchor(url, cont)
-          case "collapsed_body" => insertDetailSummary(url, embedCode, cont)
+          case "collapsed_body" => insertAnchor(url, cont)
           case _ => insertUnhandled(url, cont)
         }
 
@@ -117,7 +116,7 @@ trait LenkeConverterModule {
     }
 
     private def insertAnchor(url: String, cont: ContentBrowser): (String, Option[RequiredLibrary], Seq[String]) = {
-      val htmlTag = HtmlTagGenerator.buildAnchor(url, cont.get("link_text"), cont.get("link_title_text"))
+      val htmlTag = HtmlTagGenerator.buildAnchor(url, cont.get("link_text"), cont.get("link_title_text"), true)
       (s" $htmlTag", None, Seq())
     }
 

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterTest.scala
@@ -47,7 +47,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val insertion = "link"
     val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=$insertion==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val content = ContentBrowser(contentString, "nb")
-    val expectedResult = " <a href=\"https://www.youtube.com/watch?v=1qN72LEQnaU\" title=\"\"> </a>"
+    val expectedResult = """ <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
     val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
     result should equal(expectedResult)
@@ -59,7 +59,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val insertion = "unhandledinsertion"
     val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=$insertion==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val content = ContentBrowser(contentString, "nb")
-    val expectedResult = " <a href=\"https://www.youtube.com/watch?v=1qN72LEQnaU\" title=\"\"> </a>"
+    val expectedResult = """ <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
     val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
     result should equal(expectedResult)
@@ -71,7 +71,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val insertion = "lightbox_large"
     val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=$insertion==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val content = ContentBrowser(contentString, "nb")
-    val expectedResult = " <a href=\"https://www.youtube.com/watch?v=1qN72LEQnaU\" title=\"\"> </a>"
+    val expectedResult = """ <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
     val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
     result should equal(expectedResult)
@@ -79,17 +79,17 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     errors.messages.length should equal(0)
   }
 
-  test("That LenkeConverter returns a collapsed embed code if insertion method is 'collapsed_body'") {
+  test("That LenkeConverter returns an a-tag if insertion method is 'collapsed_body'") {
     val insertion = "collapsed_body"
     val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=$insertion==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val content = ContentBrowser(contentString, "nb")
-    val expectedResult = s"<details><summary>${content.get("link_text")}</summary>$linkEmbedCode</details>"
+    val expectedResult = s""" <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
     val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
 
     result should equal(expectedResult)
     requiredLibraries.length should equal(0)
-    errors.messages.length should equal(1)
+    errors.messages.length should equal(0)
   }
 
   test("That LenkeConverter returns inline content with nrk video id") {


### PR DESCRIPTION
Bare to av nodene som er referert til i mailen har en lightbox hvor en ekstern kilde åpnes i en lightbox. Hvorav en av dem ikke lar seg importere fga. flash (tror jeg).
Fikset det ene tilfellet. I tilegg til dette defaulter "insertion metode" til en a-tag som åpnes i en ny fane.