### PR TITLE
NDLANO/Issues#634 ingress i boks

### DIFF
--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -166,7 +166,6 @@ trait HTMLCleaner {
     private def getIngressText(el: Element): Option[Seq[Element]] = {
       val firstParagraphs = Option(el.select(">p")).map(_.asScala.toList)
         .flatMap(paragraphs => paragraphs.headOption.map(_ => paragraphs.take(2))) // select two first paragraphs
-
       val ingress = firstParagraphs.flatMap(ps => {
         val ingresses = ps.map(p => Option(p.select(">strong").first))
 
@@ -175,6 +174,12 @@ trait HTMLCleaner {
           case Some(head) :: Some(second) :: _ => Some(Seq(head, second))
           case Some(head) :: None :: _ => Some(Seq(head))
           case Some(head) :: _ => Some(Seq(head))
+          case None :: Some(second) :: _ =>
+            ps.head.select(">embed").first match {
+              case _ : Element => Some(Seq(second))
+              case _ => None
+            }
+
           case _ => None
         }
       })

--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -72,6 +72,14 @@ trait HTMLCleaner {
       if (firstSectionChildren.size != 1)
         return
 
+      // TODO: Maybe find a better way to decide if merging sections.
+      // Maybe by only merging if embed tag is rootNode in section.
+      sections.head.children.asScala.foreach{e =>
+        if (e.children.size > 2) {
+          return
+        }
+      }
+
       firstSectionChildren.select(resourceHtmlEmbedTag).asScala.headOption match {
         case Some(e) =>
           sections(1).prepend(e.outerHtml())

--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -72,13 +72,7 @@ trait HTMLCleaner {
       if (firstSectionChildren.size != 1)
         return
 
-      // TODO: Maybe find a better way to decide if merging sections.
-      // Maybe by only merging if embed tag is rootNode in section.
-      sections.head.children.asScala.foreach{e =>
-        if (e.children.size > 2) {
-          return
-        }
-      }
+      sections.head.children.asScala.foreach{e => if (e.children.size > 2) return}
 
       firstSectionChildren.select(resourceHtmlEmbedTag).asScala.headOption match {
         case Some(e) =>

--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -69,10 +69,8 @@ trait HTMLCleaner {
         return
 
       val firstSectionChildren = sections.head.children
-      if (firstSectionChildren.size != 1)
+      if (firstSectionChildren.size != 1 || firstSectionChildren.asScala.head.children.size > 2)
         return
-
-      sections.head.children.asScala.foreach{e => if (e.children.size > 2) return}
 
       firstSectionChildren.select(resourceHtmlEmbedTag).asScala.headOption match {
         case Some(e) =>

--- a/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
@@ -569,6 +569,23 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
   }
 
 
+  test("Merging should not happen in cases where there are a container with more info than an image") {
+    val originalContent = """<section>
+                            |        <div class="c-bodybox"><p><embed data-align="" data-alt="Journalist Mads A. Andersen foran PC-skjerm i VGs redaksjonslokale. Fotografi." data-caption="" data-resource="image" data-resource_id="6" data-size="fullbredde">  </p><p><strong>Det er en stille dag i redaksjonen.</strong></p><p> </p><h2>Oppdrag</h2><ol><li>Du skal lage en nyhetssak om bankranet til nyhetssendingen på lokalradio kl. 17.30 og til den lokale TV-sendingen kl. 18.40 samme dag.</li><li>Skriv teksten til den nyhetsmeldingen du vil ha på radio.</li></ol></div> </section><section>
+                            |        <h2>Kildeliste</h2> <p><strong>Kilde 1: Bankansatt</strong></p> <p><embed data-account="4806596774001" data-caption="Kildeeksempel 1: Banksjef" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:78120"> </p> </section>""".stripMargin
+
+    val expectedContent = """<section><div class="c-bodybox"><embed data-align="" data-alt="Journalist Mads A. Andersen foran PC-skjerm i VGs redaksjonslokale. Fotografi." data-caption="" data-resource="image" data-resource_id="6" data-size="fullbredde"><h2>Oppdrag</h2><ol><li>Du skal lage en nyhetssak om bankranet til nyhetssendingen på lokalradio kl. 17.30 og til den lokale TV-sendingen kl. 18.40 samme dag.</li><li>Skriv teksten til den nyhetsmeldingen du vil ha på radio.</li></ol></div></section><section><h2>Kildeliste</h2><p><strong>Kilde 1: Bankansatt</strong></p><embed data-account="4806596774001" data-caption="Kildeeksempel 1: Banksjef" data-player="BkLm8fT" data-resource="brightcove" data-videoid="ref:78120"></section>"""
+
+    val expectedIngress = """Det er en stille dag i redaksjonen."""
+
+    val Success((result, _)) = htmlCleaner.convert(TestData.sampleContent.copy(content=originalContent), defaultImportStatus)
+    result.content should equal(expectedContent)
+    result.ingress should equal(Some(LanguageIngress(expectedIngress, None)))
+
+
+  }
+
+
 
 
 }

--- a/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
@@ -581,11 +581,16 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
     val Success((result, _)) = htmlCleaner.convert(TestData.sampleContent.copy(content=originalContent), defaultImportStatus)
     result.content should equal(expectedContent)
     result.ingress should equal(Some(LanguageIngress(expectedIngress, None)))
-
-
   }
 
+  test("Ingress should still be extracted if first <p> is only an embed") {
+    val originalContent = """<section><p><embed data-height="337px" data-resource="ndla-filmiundervisning" data-url="//ndla.filmiundervisning.no/film/ndlafilm.aspx?filmId=12414" data-width="632px"></p><p><strong>I en film er det bildenes rekkefølge som skaper sammenheng og mening.</strong></p><p>Når vi ser to bilder.</p></section><div class="paragraph"><div class="full"><p><embed data-height="337px" data-resource="ndla-filmiundervisning" data-url="//ndla.filmiundervisning.no/film/ndlafilm.aspx?filmId=12414" data-width="632px">&#xa0;</p><p><strong>Something</strong></p></div></div>"""
+    val expectedContent = """<section><p><embed data-height="337px" data-resource="ndla-filmiundervisning" data-url="//ndla.filmiundervisning.no/film/ndlafilm.aspx?filmId=12414" data-width="632px"></p><p>Når vi ser to bilder.</p><div class="paragraph"><div class="full"><p><embed data-height="337px" data-resource="ndla-filmiundervisning" data-url="//ndla.filmiundervisning.no/film/ndlafilm.aspx?filmId=12414" data-width="632px"></p><p><strong>Something</strong></p></div></div></section>"""
 
+    val expectedIngress = """I en film er det bildenes rekkefølge som skaper sammenheng og mening."""
 
-
+    val Success((result, _)) = htmlCleaner.convert(TestData.sampleContent.copy(content=originalContent), defaultImportStatus)
+    result.content should equal(expectedContent)
+    result.ingress should equal(Some(LanguageIngress(expectedIngress, None)))
+  }
 }


### PR DESCRIPTION
Fikser uthentingsproblemer for ingresser hvor de finnes etter embed tags.
Fikser også uthentingsproblemer for ingresser dersom  de finnes inne i containere (feks en `<div>`)