### PR TITLE
NDLANO/Issues#580 pagination over 10000 results

### DIFF
--- a/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -47,6 +47,7 @@ object ArticleApiProperties extends LazyLogging {
   val DefaultPageSize = 10
   val MaxPageSize = 100
   val IndexBulkSize = 200
+  val ElasticSearchIndexMaxResultWindow = 10000
 
   val TopicAPIUrl = "http://api.topic.ndla.no/rest/v1/keywords/?filter[node]=ndlanode_"
   val MigrationHost = prop("MIGRATION_HOST")

--- a/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest
 
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.articleapi.ArticleApiProperties.{CorrelationIdHeader, CorrelationIdKey}
-import no.ndla.articleapi.model.api.{AccessDeniedException, Error, ImportException, ImportExceptions, NotFoundException, OptimisticLockException, ValidationError, ValidationException, ValidationMessage}
+import no.ndla.articleapi.model.api.{AccessDeniedException, Error, ImportException, ImportExceptions, NotFoundException, OptimisticLockException, ResultWindowTooLargeException, ValidationError, ValidationException, ValidationMessage}
 import no.ndla.articleapi.model.domain.ImportError
 import no.ndla.network.{ApplicationUrl, AuthUser, CorrelationID}
 import no.ndla.articleapi.model.domain.emptySomeToNone
@@ -54,6 +54,7 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
     case o: OptimisticLockException => Conflict(body=Error(Error.RESOURCE_OUTDATED, o.getMessage))
     case i: ImportExceptions => UnprocessableEntity(body=ImportError(i.message, i.errors.map(_.getMessage)))
     case im: ImportException =>  UnprocessableEntity(body=ImportError(messages=Seq(im.message)))
+    case rw: ResultWindowTooLargeException => UnprocessableEntity(body=Error(Error.WINDOW_TOO_LARGE, rw.getMessage))
     case t: Throwable => {
       logger.error(Error.GenericError.toString, t)
       InternalServerError(body=Error.GenericError)

--- a/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
@@ -27,11 +27,13 @@ object Error {
   val VALIDATION = "VALIDATION"
   val RESOURCE_OUTDATED = "RESOURCE_OUTDATED"
   val ACCESS_DENIED = "ACCESS DENIED"
+  val WINDOW_TOO_LARGE = "RESULT_WINDOW_TOO_LARGE"
 
   val VALIDATION_DESCRIPTION = "Validation Error"
   val GENERIC_DESCRIPTION = s"Ooops. Something we didn't anticipate occured. We have logged the error, and will look into it. But feel free to contact ${ArticleApiProperties.ContactEmail} if the error persists."
   val INDEX_MISSING_DESCRIPTION = s"Ooops. Our search index is not available at the moment, but we are trying to recreate it. Please try again in a few minutes. Feel free to contact ${ArticleApiProperties.ContactEmail} if the error persists."
   val RESOURCE_OUTDATED_DESCRIPTION = "The resource is outdated. Please try fetching before submitting again."
+  val WINDOW_TOO_LARGE_DESCRIPTION = s"The result window is too large. Fetching pages above ${ArticleApiProperties.ElasticSearchIndexMaxResultWindow} results are unsupported."
 
   val GenericError = Error(GENERIC, GENERIC_DESCRIPTION)
   val IndexMissingError = Error(INDEX_MISSING, INDEX_MISSING_DESCRIPTION)
@@ -45,3 +47,4 @@ class ImportExceptions(val message: String, val errors: Seq[Throwable]) extends 
 class ValidationException(message: String = "Validation Error", val errors: Seq[ValidationMessage]) extends RuntimeException(message)
 class OptimisticLockException(message: String = Error.RESOURCE_OUTDATED_DESCRIPTION) extends RuntimeException(message)
 class ConfigurationException(message: String) extends RuntimeException(message)
+class ResultWindowTooLargeException(message: String = Error.WINDOW_TOO_LARGE_DESCRIPTION) extends RuntimeException(message)

--- a/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
@@ -16,6 +16,7 @@ import io.searchbox.params.Parameters
 import no.ndla.articleapi.ArticleApiProperties
 import no.ndla.articleapi.integration.ElasticClient
 import no.ndla.articleapi.model.api
+import no.ndla.articleapi.model.api.ResultWindowTooLargeException
 import no.ndla.articleapi.model.domain._
 import no.ndla.network.ApplicationUrl
 import org.apache.lucene.search.join.ScoreMode
@@ -23,8 +24,8 @@ import org.elasticsearch.ElasticsearchException
 import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.index.query._
 import org.elasticsearch.search.builder.SearchSourceBuilder
-import scala.concurrent.ExecutionContext.Implicits.global
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -77,6 +78,7 @@ trait ArticleSearchService {
     }
 
     def executeSearch(withIdIn: List[Long], language: String, license: Option[String], sort: Sort.Value, page: Int, pageSize: Int, queryBuilder: BoolQueryBuilder): SearchResult = {
+
       val (filteredSearch, searchLanguage) = {
         val licenseFilteredSearch = license match {
           case None => queryBuilder.filter(noCopyright)
@@ -101,6 +103,12 @@ trait ArticleSearchService {
         .addIndex(searchIndex)
         .setParameter(Parameters.SIZE, numResults)
         .setParameter("from", startAt)
+
+      val requestedResultWindow = pageSize * page
+      if (requestedResultWindow > ArticleApiProperties.ElasticSearchIndexMaxResultWindow) {
+        logger.error(s"Max supported results are ${ArticleApiProperties.ElasticSearchIndexMaxResultWindow}, user requested ${requestedResultWindow}")
+        throw new ResultWindowTooLargeException()
+      }
 
       jestClient.execute(request.build()) match {
         case Success(response) => SearchResult(response.getTotal.toLong, page, numResults, searchLanguage, response)

--- a/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
@@ -106,7 +106,7 @@ trait ArticleSearchService {
 
       val requestedResultWindow = pageSize * page
       if (requestedResultWindow > ArticleApiProperties.ElasticSearchIndexMaxResultWindow) {
-        logger.error(s"Max supported results are ${ArticleApiProperties.ElasticSearchIndexMaxResultWindow}, user requested ${requestedResultWindow}")
+        logger.info(s"Max supported results are ${ArticleApiProperties.ElasticSearchIndexMaxResultWindow}, user requested ${requestedResultWindow}")
         throw new ResultWindowTooLargeException()
       }
 

--- a/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
@@ -123,7 +123,7 @@ trait IndexService {
       } else {
         val createIndexResponse = jestClient.execute(
           new CreateIndex.Builder(indexName)
-            .settings(s"{\"index\" : { \"max_result_window\" : ${ArticleApiProperties.ElasticSearchIndexMaxResultWindow} }")
+            .settings(s"""{"index":{"max_result_window":${ArticleApiProperties.ElasticSearchIndexMaxResultWindow}}}""")
             .build())
         createIndexResponse.map(_ => createMapping(indexName)).map(_ => indexName)
       }

--- a/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/IndexService.scala
@@ -121,7 +121,10 @@ trait IndexService {
       if (indexExists(indexName)) {
         Success(indexName)
       } else {
-        val createIndexResponse = jestClient.execute(new CreateIndex.Builder(indexName).build())
+        val createIndexResponse = jestClient.execute(
+          new CreateIndex.Builder(indexName)
+            .settings(s"{\"index\" : { \"max_result_window\" : ${ArticleApiProperties.ElasticSearchIndexMaxResultWindow} }")
+            .build())
         createIndexResponse.map(_ => createMapping(indexName)).map(_ => indexName)
       }
     }


### PR DESCRIPTION
- Setter `index.max_result_window` verdien i elasticsearch
- Error handling når det requestes pages etter 10000 results