### PR TITLE
support importing nodes of type lenke #648

### DIFF
--- a/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
+++ b/src/main/scala/no/ndla/articleapi/ArticleApiProperties.scala
@@ -63,7 +63,8 @@ object ArticleApiProperties extends LazyLogging {
   val nodeTypeBegrep: String = "begrep"
   val nodeTypeVideo: String = "video"
   val nodeTypeH5P: String = "h5p_content"
-  val supportedContentTypes = Set("fagstoff", "oppgave", "veiledning", "aktualitet", "emneartikkel", nodeTypeBegrep, nodeTypeVideo, nodeTypeH5P)
+  val nodeTypeLenke: String = "lenke"
+  val supportedContentTypes = Set("fagstoff", "oppgave", "veiledning", "aktualitet", "emneartikkel", nodeTypeBegrep, nodeTypeVideo, nodeTypeH5P, nodeTypeLenke)
 
 
   // When converting a content node, the converter may run several times over the content to make sure

--- a/src/main/scala/no/ndla/articleapi/integration/ConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/integration/ConverterModule.scala
@@ -59,6 +59,7 @@ case class LanguageContent(nid: String,
                            language: String,
                            visualElement: Option[String],
                            nodeType: String,
+                           contentType: Option[String],
                            title: Option[String],
                            requiredLibraries: Set[RequiredLibrary] = Set[RequiredLibrary](),
                            ingress: Option[LanguageIngress] = None) {

--- a/src/main/scala/no/ndla/articleapi/integration/MigrationApiClient.scala
+++ b/src/main/scala/no/ndla/articleapi/integration/MigrationApiClient.scala
@@ -101,6 +101,7 @@ case class MigrationMainNodeImport(titles: Seq[MigrationContentTitle], ingresses
         Language.languageOrUnknown(content.language),
         visualElements.find(_.language == content.language).map(_.element),
         nodeType.getOrElse("unknown"),
+        contentType.headOption.map(_.`type`.toLowerCase),
         titles.find(_.language == content.language).map(_.title),
         ingress = getIngress(content.language))
     })

--- a/src/main/scala/no/ndla/articleapi/model/domain/Copyright.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/Copyright.scala
@@ -8,8 +8,4 @@
 
 package no.ndla.articleapi.model.domain
 
-import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
-
-import scala.annotation.meta.field
-
 case class Copyright(license: String, origin: String, authors: Seq[Author])

--- a/src/main/scala/no/ndla/articleapi/service/ConverterModules.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ConverterModules.scala
@@ -12,7 +12,7 @@ package no.ndla.articleapi.service
 import no.ndla.articleapi.integration.ConverterModule
 import no.ndla.articleapi.model.api.ImportExceptions
 import no.ndla.articleapi.model.domain.{ImportStatus, NodeToConvert}
-import no.ndla.articleapi.ArticleApiProperties.{nodeTypeBegrep, nodeTypeVideo, nodeTypeH5P}
+import no.ndla.articleapi.ArticleApiProperties.{nodeTypeBegrep, nodeTypeVideo, nodeTypeH5P, nodeTypeLenke}
 
 import scala.util.{Failure, Success, Try}
 
@@ -26,7 +26,8 @@ trait ConverterModules {
   private lazy val Converters = Map(
     nodeTypeBegrep -> conceptConverter,
     nodeTypeH5P -> leafNodeConverter,
-    nodeTypeVideo -> leafNodeConverter
+    nodeTypeVideo -> leafNodeConverter,
+    nodeTypeLenke -> leafNodeConverter
   ).withDefaultValue(articleConverter)
 
   def executeConverterModules(nodeToConvert: NodeToConvert, importStatus: ImportStatus): Try[(NodeToConvert, ImportStatus)] =

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterModule.scala
@@ -39,7 +39,7 @@ trait LenkeConverterModule {
         val (url, embedCode) = (meta.url.getOrElse(""), meta.embedCode.getOrElse(""))
         val (htmlTag, requiredLibrary, errors) = cont.get("insertion") match {
           case "link" => insertAnchor(url, cont)
-          case "inline" => insertInline(url, embedCode, cont)
+          case "inline" => insertInlineLink(url, embedCode)
           case "lightbox_large" => insertAnchor(url, cont)
           case "collapsed_body" => insertAnchor(url, cont)
           case _ => insertUnhandled(url, cont)
@@ -62,7 +62,7 @@ trait LenkeConverterModule {
       }
     }
 
-    private def insertInline(url: String, embedCode: String, cont: ContentBrowser): (String, Option[RequiredLibrary], Seq[String]) = {
+    def insertInlineLink(url: String, embedCode: String): (String, Option[RequiredLibrary], Seq[String]) = {
       val message = s"External resource to be embedded: $url"
       logger.info(message)
 
@@ -120,7 +120,7 @@ trait LenkeConverterModule {
     }
 
     private def insertDetailSummary(url: String, embedCode: String, cont: ContentBrowser): (String, Option[RequiredLibrary], Seq[String]) = {
-      val (elementToInsert, requiredLib, figureErrors) = insertInline(url, embedCode, cont)
+      val (elementToInsert, requiredLib, figureErrors) = insertInlineLink(url, embedCode)
       (s"<details><summary>${cont.get("link_text")}</summary>$elementToInsert</details>", requiredLib, figureErrors)
     }
 

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -292,7 +292,7 @@ object TestData {
 
   val (nodeId, nodeId2) = ("1234", "4321")
   val sampleTitle = ArticleTitle("title", "en")
-  val sampleContent = LanguageContent(nodeId, nodeId, "sample content", "metadescription", "en", None, "fagstoff", Some("title"))
+  val sampleContent = LanguageContent(nodeId, nodeId, "sample content", "metadescription", "en", None, "fagstoff", Some("fagstoff"), Some("title"))
   val sampleTranslationContent = sampleContent.copy(tnid=nodeId2)
 
   val visualElement = VisualElement(s"""<$resourceHtmlEmbedTag  data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />""", "nb")

--- a/src/test/scala/no/ndla/articleapi/service/converters/LeafNodeConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/LeafNodeConverterTest.scala
@@ -11,8 +11,12 @@ package no.ndla.articleapi.service.converters
 import no.ndla.articleapi.model.domain.ImportStatus
 import no.ndla.articleapi.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.articleapi.ArticleApiProperties.resourceHtmlEmbedTag
+import no.ndla.articleapi.integration.MigrationEmbedMeta
+import no.ndla.articleapi.model.api.ImportException
+import org.mockito.Mockito._
+import org.mockito.Matchers._
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 class LeafNodeConverterTest extends UnitSuite with TestEnvironment {
   val nodeId = "1234"
@@ -33,6 +37,27 @@ class LeafNodeConverterTest extends UnitSuite with TestEnvironment {
 
     result.content should equal (expectedResult)
     result.requiredLibraries.size should equal (1)
+  }
+
+  test("Leaf node converter should create an article from a pure lenke/ekstern ressurs node") {
+    val sampleLanguageContent = TestData.sampleContent.copy(content="<div><h1>hi</h1></div>", nodeType = "lenke", contentType = Some("ekstern ressurs"))
+    val url = "https://www.youtube.com/watch?v=dNfpRZi42hQ"
+
+    when(extractService.getNodeEmbedMeta(any[String])).thenReturn(Success(MigrationEmbedMeta(Some(url), Some("<iframe src=\"$url\""))))
+
+    val expectedResult = s"""${sampleLanguageContent.content}<section><$resourceHtmlEmbedTag data-resource="external" data-url="$url"></section>"""
+    val Success((result, _)) = LeafNodeConverter.convert(sampleLanguageContent, ImportStatus(Seq(), Seq()))
+
+    result.content should equal (expectedResult)
+    result.requiredLibraries.size should equal (0)
+  }
+
+  test("Leaf node converter should return a failure if node type is unsupported") {
+    val sampleLanguageContent = TestData.sampleContent.copy(nodeType = "lolol")
+
+    val Failure(ex) = LeafNodeConverter.convert(sampleLanguageContent, ImportStatus.empty)
+    ex.isInstanceOf[ImportException] should be (true)
+    ex.getMessage.contains("unsupported node/content -type:") should be(true)
   }
 
 }


### PR DESCRIPTION
Det er fremdeles et problem at mange av nodene med nodetype "lenke" ikke har noen lisens tilknyttet seg. Disse vil ikke la seg importere fordi vi har lisens som et påkrevd lisens.
Litt usikker hva vi skal gjøre med disse. Tenker vi kanskje bør høre med NDLA-folket om de har noen meninger om det, @runesto? Eller så kan vi bare håndtere det, og gjøre copyright til et optional felt, men det tror jeg er ganske dumt.