### PR TITLE
Ndlano/issues#694 article import should always update db

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -55,8 +55,9 @@ trait InternController {
 
     post("/import/:external_id") {
       val externalId = params("external_id")
+      val forceUpdateArticle = booleanOrDefault("forceUpdate", false)
 
-      extractConvertStoreContent.processNode(externalId) match {
+      extractConvertStoreContent.processNode(externalId, forceUpdateArticle) match {
         case Success((content, status)) => status.addMessage(s"Successfully imported node $externalId: ${content.id.get}")
         case Failure(exc) => errorHandler(exc)
       }

--- a/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
@@ -101,6 +101,12 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
     }
   }
 
+  def booleanOrNone(paramName: String)(implicit request: HttpServletRequest): Option[Boolean] =
+    paramOrNone(paramName).flatMap(p => Try(p.toBoolean).toOption)
+
+  def booleanOrDefault(paramName: String, default: Boolean)(implicit request: HttpServletRequest): Boolean =
+    booleanOrNone(paramName).getOrElse(default)
+
   def extract[T](json: String)(implicit mf: scala.reflect.Manifest[T]): T = {
     Try {
       read[T](json)

--- a/src/main/scala/no/ndla/articleapi/model/domain/ImportStatus.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/ImportStatus.scala
@@ -9,18 +9,17 @@
 
 package no.ndla.articleapi.model.domain
 
-case class ImportStatus(messages: Seq[String], visitedNodes: Seq[String] = Seq(), articleId: Option[Long] = None, forceUpdateArticle: Boolean = false) {
+case class ImportStatus(messages: Seq[String], visitedNodes: Seq[String] = Seq(), articleId: Option[Long] = None) {
   def ++(importStatus: ImportStatus): ImportStatus =
     ImportStatus(messages ++ importStatus.messages, visitedNodes ++ importStatus.visitedNodes, importStatus.articleId)
   def addMessage(message: String): ImportStatus = this.copy(messages = this.messages :+ message)
   def addMessages(messages: Seq[String]): ImportStatus = this.copy(messages = this.messages ++ messages)
   def addVisitedNode(nodeId: String): ImportStatus = this.copy(visitedNodes = this.visitedNodes :+ nodeId)
   def setArticleId(id: Long): ImportStatus = this.copy(articleId = Some(id))
-  def setForceUpdateArticle(forceUpdateArticle: Boolean): ImportStatus = this.copy(forceUpdateArticle=forceUpdateArticle)
 }
 
 object ImportStatus {
-  def empty = ImportStatus(Seq.empty, Seq.empty, None, false)
+  def empty = ImportStatus(Seq.empty, Seq.empty, None)
   def apply(message: String, visitedNodes: Seq[String]): ImportStatus = ImportStatus(Seq(message), visitedNodes, None)
   def apply(importStatuses: Seq[ImportStatus]): ImportStatus = {
     val (messages, visitedNodes, articleIds) = importStatuses.map(x => (x.messages, x.visitedNodes, x.articleId)).unzip3

--- a/src/main/scala/no/ndla/articleapi/model/domain/ImportStatus.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/ImportStatus.scala
@@ -9,17 +9,18 @@
 
 package no.ndla.articleapi.model.domain
 
-case class ImportStatus(messages: Seq[String], visitedNodes: Seq[String] = Seq(), articleId: Option[Long] = None) {
+case class ImportStatus(messages: Seq[String], visitedNodes: Seq[String] = Seq(), articleId: Option[Long] = None, forceUpdateArticle: Boolean = false) {
   def ++(importStatus: ImportStatus): ImportStatus =
     ImportStatus(messages ++ importStatus.messages, visitedNodes ++ importStatus.visitedNodes, importStatus.articleId)
   def addMessage(message: String): ImportStatus = this.copy(messages = this.messages :+ message)
   def addMessages(messages: Seq[String]): ImportStatus = this.copy(messages = this.messages ++ messages)
-  def setArticleId(id: Long): ImportStatus = this.copy(articleId = Some(id))
   def addVisitedNode(nodeId: String): ImportStatus = this.copy(visitedNodes = this.visitedNodes :+ nodeId)
+  def setArticleId(id: Long): ImportStatus = this.copy(articleId = Some(id))
+  def setForceUpdateArticle(forceUpdateArticle: Boolean): ImportStatus = this.copy(forceUpdateArticle=forceUpdateArticle)
 }
 
 object ImportStatus {
-  def empty = ImportStatus(Seq.empty, Seq.empty, None)
+  def empty = ImportStatus(Seq.empty, Seq.empty, None, false)
   def apply(message: String, visitedNodes: Seq[String]): ImportStatus = ImportStatus(Seq(message), visitedNodes, None)
   def apply(importStatuses: Seq[ImportStatus]): ImportStatus = {
     val (messages, visitedNodes, articleIds) = importStatuses.map(x => (x.messages, x.visitedNodes, x.articleId)).unzip3

--- a/src/main/scala/no/ndla/articleapi/model/domain/ImportStatus.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/ImportStatus.scala
@@ -13,7 +13,9 @@ case class ImportStatus(messages: Seq[String], visitedNodes: Seq[String] = Seq()
   def ++(importStatus: ImportStatus): ImportStatus =
     ImportStatus(messages ++ importStatus.messages, visitedNodes ++ importStatus.visitedNodes, importStatus.articleId)
   def addMessage(message: String): ImportStatus = this.copy(messages = this.messages :+ message)
-  def setArticleId(id: Long) = this.copy(articleId = Some(id))
+  def addMessages(messages: Seq[String]): ImportStatus = this.copy(messages = this.messages ++ messages)
+  def setArticleId(id: Long): ImportStatus = this.copy(articleId = Some(id))
+  def addVisitedNode(nodeId: String): ImportStatus = this.copy(visitedNodes = this.visitedNodes :+ nodeId)
 }
 
 object ImportStatus {

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -98,7 +98,7 @@ trait ArticleRepository {
       val startRevision = 1
       Try(sql"update ${Article.table} set document=${dataObject}, revision=$startRevision where external_id=${externalId}".updateAndReturnGeneratedKey().apply) match {
         case Success(articleId) =>
-          logger.info(s"Updated article with external_id=$externalId, id=$articleId")
+          logger.info(s"Updated article with external_id=$externalId, id=$articleId. Revision reset to 1")
           Success(article.copy(id=Some(articleId)))
         case Failure(ex) =>
           logger.warn(s"Failed to update article with external id $externalId: ${ex.getMessage}")

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -90,6 +90,22 @@ trait ArticleRepository {
       }
     }
 
+    def updateWithExternalIdOverrideManualChanges(article: Article, externalId: String)(implicit session: DBSession = AutoSession): Try[Article] = {
+      val dataObject = new PGobject()
+      dataObject.setType("jsonb")
+      dataObject.setValue(write(article))
+
+      val startRevision = 1
+      Try(sql"update ${Article.table} set document=${dataObject}, revision=$startRevision where external_id=${externalId}".updateAndReturnGeneratedKey().apply) match {
+        case Success(articleId) =>
+          logger.info(s"Updated article with external_id=$externalId, id=$articleId")
+          Success(article.copy(id=Some(articleId)))
+        case Failure(ex) =>
+          logger.warn(s"Failed to update article with external id $externalId: ${ex.getMessage}")
+          Failure(ex)
+      }
+    }
+
     def delete(articleId: Long)(implicit session: DBSession = AutoSession) = {
       sql"delete from ${Article.table} where id = $articleId".update().apply
     }

--- a/src/main/scala/no/ndla/articleapi/service/ExtractConvertStoreContent.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ExtractConvertStoreContent.scala
@@ -35,9 +35,9 @@ trait ExtractConvertStoreContent {
 
   class ExtractConvertStoreContent extends LazyLogging {
     def processNode(externalId: String, forceUpdateArticles: Boolean): Try[(Content, ImportStatus)] =
-      processNode(externalId, ImportStatus.empty.setForceUpdateArticle(forceUpdateArticles))
+      processNode(externalId, ImportStatus.empty, forceUpdateArticles)
 
-    def processNode(externalId: String, importStatus: ImportStatus = ImportStatus.empty): Try[(Content, ImportStatus)] = {
+    def processNode(externalId: String, importStatus: ImportStatus = ImportStatus.empty, forceUpdateArticles: Boolean = false): Try[(Content, ImportStatus)] = {
       if (importStatus.visitedNodes.contains(externalId)) {
         return getMainNodeId(externalId).flatMap(readService.getContentByExternalId) match {
           case Some(content) => Success(content, importStatus)
@@ -49,7 +49,7 @@ trait ExtractConvertStoreContent {
         (node, mainNodeId) <- extract(externalId)
         (convertedContent, updatedImportStatus) <- convert(node, importStatus)
         _ <- importValidator.validate(convertedContent, allowUnknownLanguage=true)
-        content <- store(convertedContent, mainNodeId, importStatus.forceUpdateArticle)
+        content <- store(convertedContent, mainNodeId, forceUpdateArticles)
         _ <- indexContent(content)
       } yield (content, updatedImportStatus.addMessage(s"Successfully imported node $externalId: ${content.id.get}").setArticleId(content.id.get))
 

--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -45,7 +45,7 @@ trait HTMLCleaner {
       val finalCleanedDocument = allContentMustBeWrappedInSectionBlocks(element)
 
       Success((content.copy(content=jsoupDocumentToString(finalCleanedDocument), metaDescription=metaDescription, ingress=ingress),
-        ImportStatus(importStatus.messages ++ illegalTags ++ illegalAttributes, importStatus.visitedNodes)))
+        importStatus.addMessages(illegalTags ++ illegalAttributes)))
     }
 
     private def unwrapDivsAroundDetailSummaryBox(element: Element) {

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/AudioConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/AudioConverterModule.scala
@@ -24,12 +24,12 @@ trait AudioConverterModule  {
   object AudioConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "audio"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val nodeId = content.get("nid")
       logger.info(s"Converting audio with nid $nodeId")
 
       toAudio(nodeId) match {
-        case Success(audioHtml) => Success((audioHtml, Seq.empty, ImportStatus(Seq(), visitedNodes)))
+        case Success(audioHtml) => Success((audioHtml, Seq.empty, importStatus))
         case Failure(_) => Failure(ImportException(s"Failed to import audio with node id $nodeId"))
       }
     }

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/BegrepConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/BegrepConverterModule.scala
@@ -23,12 +23,12 @@ trait BegrepConverterModule {
   object BegrepConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "begrep"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val nodeId = content.get("nid")
-      extractConvertStoreContent.processNode(nodeId, ImportStatus(Seq.empty, visitedNodes)) match {
-        case Success((c: Concept, importStatus)) =>
+      extractConvertStoreContent.processNode(nodeId, importStatus) match {
+        case Success((c: Concept, is)) =>
           val embedContent = HtmlTagGenerator.buildConceptEmbedContent(c.id.get, content.get("link_text"))
-          Success((embedContent, Seq.empty, ImportStatus(s"Imported concept with id ${c.id}", importStatus.visitedNodes)))
+          Success((embedContent, Seq.empty, is.addMessage(s"Imported concept with id ${c.id}")))
 
         case Success((x: Article, _)) =>
           val msg = s"THIS IS A BUG: Imported begrep node with nid $nodeId but is marked as an article (id ${x.id})"

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/BiblioConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/BiblioConverterModule.scala
@@ -23,7 +23,7 @@ trait BiblioConverterModule {
   object BiblioConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "biblio"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val nodeId = content.get("nid")
       getFootNoteData(nodeId) match {
         case None => Failure(ImportException(s"Failed to fetch biblio meta data with node id $nodeId"))
@@ -34,7 +34,7 @@ trait BiblioConverterModule {
           edition = meta.edition,
           publisher = meta.publisher,
           authors = meta.authors
-        ), List[RequiredLibrary](), ImportStatus(Seq.empty, visitedNodes))
+        ), List[RequiredLibrary](), importStatus)
       }
     }
 

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/ContentBrowserConverter.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/ContentBrowserConverter.scala
@@ -60,21 +60,17 @@ trait ContentBrowserConverter {
 
         val converterModule = getConverterModule(cont)
 
-        converterModule.convert(cont, importStatus.visitedNodes) match {
-          case Failure(x) => {
+        converterModule.convert(cont, importStatus) match {
+          case Failure(x) =>
             val (start, end) = cont.getStartEndIndex()
             replaceHtmlInElement(element, start, end, "")
             convert(element, languageContent, importStatus, exceptions :+ x)
-          }
-          case Success((newContent, reqLibs, status)) => {
+          case Success((newContent, reqLibs, status)) =>
             val (start, end) = cont.getStartEndIndex()
             replaceHtmlInElement(element, start, end, newContent)
 
             val updatedRequiredLibraries = languageContent.requiredLibraries ++ reqLibs
-            val updatedImportStatusMessages = importStatus.messages ++ status.messages
-            convert(element, languageContent.copy(requiredLibraries = updatedRequiredLibraries),
-              status.copy(messages = updatedImportStatusMessages), exceptions)
-          }
+            convert(element, languageContent.copy(requiredLibraries = updatedRequiredLibraries), status, exceptions)
         }
       }
 

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/ContentBrowserConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/ContentBrowserConverterModule.scala
@@ -24,7 +24,7 @@ import scala.util.Try
 
 
 trait ContentBrowserConverterModule {
-  def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)]
+  def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)]
   val typeName: String
 }
 

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/FilConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/FilConverterModule.scala
@@ -23,12 +23,12 @@ trait FilConverterModule {
   object FilConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "fil"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val nodeId = content.get("nid")
       val importedFile = for {
         fileMeta <- extractService.getNodeFilMeta(nodeId)
         filePath <- attachmentStorageService.uploadFileFromUrl(nodeId, fileMeta)
-      } yield (HtmlTagGenerator.buildAnchor(s"$Domain/files/$filePath", fileMeta.fileName, fileMeta.fileName, openInNewTab=false), Seq.empty, ImportStatus(Seq.empty, visitedNodes))
+      } yield (HtmlTagGenerator.buildAnchor(s"$Domain/files/$filePath", fileMeta.fileName, fileMeta.fileName, openInNewTab=false), Seq.empty, importStatus)
 
       importedFile match {
         case Success(x) => Success(x)

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/GeneralContentConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/GeneralContentConverterModule.scala
@@ -21,13 +21,13 @@ trait GeneralContentConverterModule {
   this: ExtractService with ReadService with ExtractConvertStoreContent with HtmlTagGenerator =>
 
   abstract class GeneralContentConverter extends ContentBrowserConverterModule with LazyLogging {
-    override def convert(contentBrowser: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(contentBrowser: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val externalId = contentBrowser.get("nid")
       val contents = extractService.getNodeGeneralContent(externalId)
 
       contents.find(x => x.language == contentBrowser.language) match {
         case Some(content) =>
-          insertContent(content.content, contentBrowser, visitedNodes) map { case (finalContent, status) =>
+          insertContent(content.content, contentBrowser, importStatus) map { case (finalContent, status) =>
             (finalContent, Seq(), status)
           }
         case None =>
@@ -35,40 +35,41 @@ trait GeneralContentConverterModule {
       }
     }
 
-    def insertContent(content: String, contentBrowser: ContentBrowser, visitedNodes: Seq[String]): Try[(String, ImportStatus)] = {
+    def insertContent(content: String, contentBrowser: ContentBrowser, importStatus: ImportStatus): Try[(String, ImportStatus)] = {
       val insertionMethod = contentBrowser.get("insertion")
       insertionMethod match {
-        case "inline" => Success(content, ImportStatus(Seq(), visitedNodes))
+        case "inline" => Success(content, importStatus)
         case "collapsed_body" =>
-          Success(HtmlTagGenerator.buildDetailsSummaryContent(contentBrowser.get("link_text"), content), ImportStatus(Seq(), visitedNodes))
-        case "link" => insertLink(contentBrowser, visitedNodes)
+          Success(HtmlTagGenerator.buildDetailsSummaryContent(contentBrowser.get("link_text"), content), importStatus)
+        case "link" => insertLink(contentBrowser, importStatus)
         case _ =>
           val warnMessage = s"""Unhandled insertion method '$insertionMethod' on '${contentBrowser.get("link_text")}'. Defaulting to link."""
           logger.warn(warnMessage)
-          insertLink(contentBrowser, visitedNodes) map { case (insertString, importStatus) =>
-            (insertString, ImportStatus(importStatus.messages :+ warnMessage, importStatus.visitedNodes))
+          insertLink(contentBrowser, importStatus) map {
+            case (insertString, is) =>
+              (insertString, is.addMessage(warnMessage))
           }
       }
     }
 
-    def insertLink(contentBrowser: ContentBrowser, visitedNodes: Seq[String]): Try[(String, ImportStatus)] = {
-      getContentId(contentBrowser.get("nid"), visitedNodes) match {
-        case Success((article: Article, importStatus)) =>
+    def insertLink(contentBrowser: ContentBrowser, importStatus: ImportStatus): Try[(String, ImportStatus)] = {
+      getContentId(contentBrowser.get("nid"), importStatus) match {
+        case Success((article: Article, is)) =>
           val embedContent = HtmlTagGenerator.buildLinkEmbedContent(article.id.get.toString, contentBrowser.get("link_text"))
-          Success(s" $embedContent", importStatus)
+          Success(s" $embedContent", is)
 
-        case Success((concept: Concept, importStatus)) =>
+        case Success((concept: Concept, is)) =>
           val embedContent = HtmlTagGenerator.buildConceptEmbedContent(concept.id.get, contentBrowser.get("link_text"))
-          Success(s" $embedContent", importStatus)
+          Success(s" $embedContent", is)
 
         case Failure(e) => Failure(e)
       }
     }
 
-    def getContentId(externalId: String, visitedNodes: Seq[String]): Try[(Content, ImportStatus)] = {
+    def getContentId(externalId: String, importStatus: ImportStatus): Try[(Content, ImportStatus)] = {
       readService.getContentByExternalId(externalId) match {
-        case Some(content) => Success(content, ImportStatus(Seq(), (visitedNodes :+ externalId).distinct))
-        case None => extractConvertStoreContent.processNode(externalId, ImportStatus(Seq(), visitedNodes))
+        case Some(content) => Success(content, importStatus.addVisitedNode(externalId))
+        case None => extractConvertStoreContent.processNode(externalId, importStatus)
       }
     }
 

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/H5PConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/H5PConverterModule.scala
@@ -23,12 +23,12 @@ trait H5PConverterModule {
   object H5PConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "h5p_content"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val nodeId = content.get("nid")
 
       logger.info(s"Converting h5p_content with nid $nodeId")
       val (replacement, requiredLibrary) = toH5PEmbed(nodeId)
-      Success(replacement, Seq(requiredLibrary), ImportStatus(Seq(), visitedNodes))
+      Success(replacement, Seq(requiredLibrary), importStatus)
     }
 
     def toH5PEmbed(nodeId: String): (String, RequiredLibrary) = {

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/ImageConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/ImageConverterModule.scala
@@ -23,10 +23,10 @@ trait ImageConverterModule {
   object ImageConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "image"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val nodeId = content.get("nid")
       logger.info(s"Converting image with nid $nodeId")
-      val a = getImage(content).map(imageHtml => (imageHtml, Seq(), ImportStatus(Seq(), visitedNodes))) match {
+      val a = getImage(content).map(imageHtml => (imageHtml, Seq(), importStatus)) match {
         case Success(x) => Success(x)
         case Failure(_) => Failure(ImportException(s"Failed to import image with node id $nodeId"))
       }

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/JoubelH5PConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/JoubelH5PConverterModule.scala
@@ -23,13 +23,13 @@ trait JoubelH5PConverterModule {
     override val typeName: String = "h5p_content"
     val JoubelH5PBaseUrl = "https://ndlah5p.joubel.com/node"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val ndlaNodeId = content.get("nid")
 
       ValidH5PNodeIds.get(ndlaNodeId) match {
         case Some(joubelNodeId) => Success(validH5PResource(joubelNodeId, content),
-          Seq(), ImportStatus(Seq(), visitedNodes))
-        case None => Success(invalidH5PResource(ndlaNodeId, content, visitedNodes))
+          Seq(), importStatus)
+        case None => Success(invalidH5PResource(ndlaNodeId, content, importStatus))
       }
     }
 
@@ -39,13 +39,13 @@ trait JoubelH5PConverterModule {
       HtmlTagGenerator.buildH5PEmbedContent(s"$JoubelH5PBaseUrl/${ValidH5PNodeIds(ndlaNodeId)}")
     }
 
-    private def invalidH5PResource(nodeId: String, content: ContentBrowser, visitedNodes: Seq[String]) = {
+    private def invalidH5PResource(nodeId: String, content: ContentBrowser, importStatus: ImportStatus): (String, Seq[RequiredLibrary], ImportStatus) = {
       val ndlaNodeId = content.get("nid")
       val message = s"H5P node $ndlaNodeId is not yet exported to new H5P service"
       logger.error(message)
 
       val replacement = HtmlTagGenerator.buildErrorContent(message)
-      (replacement, Seq(), ImportStatus(message, visitedNodes))
+      (replacement, Seq(), importStatus.addMessage(message))
     }
 
   }

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterModule.scala
@@ -25,11 +25,11 @@ trait LenkeConverterModule {
   object LenkeConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "lenke"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       logger.info(s"Converting lenke with nid ${content.get("nid")}")
 
       convertLink(content) match {
-        case Success((linkHtml, requiredLibraries, errors)) => Success(linkHtml, requiredLibraries, ImportStatus(errors, visitedNodes))
+        case Success((linkHtml, requiredLibraries, errors)) => Success(linkHtml, requiredLibraries, importStatus.addMessages(errors))
         case Failure(x) => Failure(x)
       }
     }

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/NonExistentNodeConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/NonExistentNodeConverterModule.scala
@@ -20,7 +20,7 @@ trait NonExistentNodeConverterModule {
   object NonExistentNodeConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "NodeDoesNotExist"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       Failure(ImportException(s"Found nonexistant node with id ${content.get("nid")}"))
     }
   }

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/UnsupportedContentConverter.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/UnsupportedContentConverter.scala
@@ -22,7 +22,7 @@ trait UnsupportedContentConverter {
   object UnsupportedContentConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "unsupported content"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val nodeType = extractService.getNodeType(content.get("nid")).getOrElse("unknown")
       val errorMessage = s"Unsupported content $nodeType in node with id ${content.get("nid")}"
       logger.error(errorMessage)

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterModule.scala
@@ -23,7 +23,7 @@ trait VideoConverterModule {
   object VideoConverter extends ContentBrowserConverterModule with LazyLogging {
     override val typeName: String = "video"
 
-    override def convert(content: ContentBrowser, visitedNodes: Seq[String]): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
+    override def convert(content: ContentBrowser, importStatus: ImportStatus): Try[(String, Seq[RequiredLibrary], ImportStatus)] = {
       val (linkText, nodeId) = (content.get("link_text"), content.get("nid"))
 
       val (embedVideo, requiredLibraries) = content.get("insertion") match {
@@ -36,7 +36,7 @@ trait VideoConverterModule {
       }
 
       logger.info(s"Added video with nid ${content.get("nid")}")
-      Success(embedVideo, requiredLibraries, ImportStatus(Seq(), visitedNodes))
+      Success(embedVideo, requiredLibraries, importStatus)
     }
 
     private def toVideoLink(linkText: String, nodeId: String): Try[String] = {

--- a/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterModule.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterModule.scala
@@ -40,7 +40,7 @@ trait VideoConverterModule {
     }
 
     private def toVideoLink(linkText: String, nodeId: String): Try[String] = {
-      extractConvertStoreContent.processNode(nodeId) match {
+      extractConvertStoreContent.processNode(nodeId, ImportStatus.empty) match {
         case Success((content, _)) => Success(HtmlTagGenerator.buildLinkEmbedContent(s"${content.id.get}", linkText))
         case Failure(ex) => Failure(ex)
       }

--- a/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/InternControllerTest.scala
@@ -41,9 +41,9 @@ class InternControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   test("That POST /import/:node_id returns a json status-object on success") {
     val newNodeId: Long = 4444
     val newArticle = TestData.sampleArticleWithByNcSa.copy(id=Some(newNodeId))
-    when(extractConvertStoreContent.processNode(nodeId)).thenReturn(Try((newArticle, ImportStatus(Seq(), Seq()))))
+    when(extractConvertStoreContent.processNode(nodeId, false)).thenReturn(Try((newArticle, ImportStatus.empty)))
 
-    post(s"/import/$nodeId") {
+    post(s"/import/$nodeId", "forceUpdate" -> "false") {
       status should equal(200)
       val convertedBody = read[ImportStatus](body)
       convertedBody should equal (ImportStatus(s"Successfully imported node $nodeId: $newNodeId", Seq()))
@@ -51,9 +51,9 @@ class InternControllerTest extends UnitSuite with TestEnvironment with ScalatraF
   }
 
   test("That POST /import/:node_id status code is 500 with a message if processNode fails") {
-    when(extractConvertStoreContent.processNode(nodeId)).thenReturn(Failure(new RuntimeException("processNode failed")))
+    when(extractConvertStoreContent.processNode(nodeId, false)).thenReturn(Failure(new RuntimeException("processNode failed")))
 
-    post(s"/import/$nodeId") {
+    post(s"/import/$nodeId", "forceUpdate" -> "false") {
       status should equal(500)
     }
   }

--- a/src/test/scala/no/ndla/articleapi/service/ExtractConvertStoreContentTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ExtractConvertStoreContentTest.scala
@@ -122,13 +122,13 @@ class ExtractConvertStoreContentTest extends UnitSuite with TestEnvironment {
   }
 
   test("Articles should be force-updated if flag is set") {
-    val status = ImportStatus.empty.setForceUpdateArticle(true)
+    val status = ImportStatus.empty
     val sampleArticle = TestData.sampleArticleWithPublicDomain
     when(extractConvertStoreContent.processNode(nodeId2, status.addVisitedNode(nodeId))).thenReturn(Try((sampleArticle, ImportStatus(Seq(), Seq(nodeId, nodeId2)))))
     when(articleRepository.exists(nodeId)).thenReturn(true)
     when(articleRepository.updateWithExternalIdOverrideManualChanges(any[Article], any[String])(any[DBSession])).thenReturn(Success(sampleArticle))
 
-    val result = eCSService.processNode(nodeId, status)
+    val result = eCSService.processNode(nodeId, status, forceUpdateArticles = true)
     result should equal(Success(sampleArticle, ImportStatus(List(s"Successfully imported node $nodeId: 1"), List(nodeId, nodeId2), sampleArticle.id)))
     verify(articleRepository, times(1)).updateWithExternalIdOverrideManualChanges(any[Article], any[String])
     verify(articleRepository, times(0)).updateWithExternalId(any[Article], any[String])

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/AudioConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/AudioConverterTest.scala
@@ -11,6 +11,7 @@ package no.ndla.articleapi.service.converters.contentbrowser
 
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import no.ndla.articleapi.ArticleApiProperties.resourceHtmlEmbedTag
+import no.ndla.articleapi.model.domain.ImportStatus
 import org.mockito.Mockito._
 
 import scala.util.{Failure, Success}
@@ -27,7 +28,7 @@ class AudioConverterTest extends UnitSuite with TestEnvironment {
 
     when(audioApiClient.getOrImportAudio(nodeId)).thenReturn(Success(audioId))
 
-    val Success((result, requiredLibraries, status)) = AudioConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, status)) = AudioConverter.convert(content, ImportStatus.empty)
     val strippedResult = " +".r.replaceAllIn(result.replace("\n", ""), " ")
 
     status.messages.isEmpty should be (true)
@@ -37,6 +38,6 @@ class AudioConverterTest extends UnitSuite with TestEnvironment {
 
   test("That AudioConverter returns a Failure if the audio was not found") {
     when(audioApiClient.getOrImportAudio(nodeId)).thenReturn(Failure(new RuntimeException("error")))
-    AudioConverter.convert(content, Seq()).isFailure should be (true)
+    AudioConverter.convert(content, ImportStatus.empty).isFailure should be (true)
   }
 }

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/BegrepConverterModuleTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/BegrepConverterModuleTest.scala
@@ -18,7 +18,7 @@ class BegrepConverterModuleTest extends UnitSuite with TestEnvironment {
     when(extractConvertStoreContent.processNode(nodeId, ImportStatus.empty)).thenReturn(Success((TestData.sampleConcept, ImportStatus.empty)))
 
     val expectedResult = s"""<$resourceHtmlEmbedTag data-content-id="1" data-link-text="$linkText" data-resource="concept" />"""
-    val Success((result, requiredLibs, _)) = BegrepConverter.convert(content, Seq.empty)
+    val Success((result, requiredLibs, _)) = BegrepConverter.convert(content, ImportStatus.empty)
 
     requiredLibs.isEmpty should be (true)
     result should equal(expectedResult)
@@ -26,7 +26,7 @@ class BegrepConverterModuleTest extends UnitSuite with TestEnvironment {
 
   test("begrepconverter should return a failure if node is not a begrep") {
     when(extractConvertStoreContent.processNode(nodeId, ImportStatus.empty)).thenReturn(Success((TestData.sampleArticleWithByNcSa, ImportStatus.empty)))
-    val result = BegrepConverter.convert(content, Seq.empty)
+    val result = BegrepConverter.convert(content, ImportStatus.empty)
 
     result.isFailure should be (true)
     val exceptionMsg = result.failed.get.asInstanceOf[ImportException].message
@@ -35,7 +35,7 @@ class BegrepConverterModuleTest extends UnitSuite with TestEnvironment {
 
   test("begrepconverter should return a failure if node failed to be imported") {
     when(extractConvertStoreContent.processNode(nodeId, ImportStatus.empty)).thenReturn(Failure(new ValidationException(errors=Seq.empty)))
-    val result = BegrepConverter.convert(content, Seq.empty)
+    val result = BegrepConverter.convert(content, ImportStatus.empty)
 
     result.isFailure should be (true)
   }

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/BiblioConverterModuleTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/BiblioConverterModuleTest.scala
@@ -9,9 +9,10 @@
 
 package no.ndla.articleapi.service.converters.contentbrowser
 
-import no.ndla.articleapi.model.domain.{Biblio, BiblioAuthor, BiblioMeta}
+import no.ndla.articleapi.model.domain.{Biblio, BiblioAuthor, BiblioMeta, ImportStatus}
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import no.ndla.articleapi.ArticleApiProperties.resourceHtmlEmbedTag
+
 import scala.util.Success
 import org.mockito.Mockito._
 
@@ -29,7 +30,7 @@ class BiblioConverterModuleTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-authors="${biblio.authors.head.name}" data-edition="${biblio.biblio.edition}" data-publisher="${biblio.biblio.publisher}" data-resource="footnote" data-title="${biblio.biblio.title}" data-type="${biblio.biblio.bibType}" data-year="${biblio.biblio.year}" />"""
 
     when(extractService.getBiblioMeta(nodeId)).thenReturn(Some(biblio))
-    val Success((result, requiredLibraries, importStatus)) = BiblioConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, importStatus)) = BiblioConverter.convert(content, ImportStatus.empty)
 
     result should equal (expectedResult)
     requiredLibraries.isEmpty should be (true)

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/FilConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/FilConverterTest.scala
@@ -9,7 +9,7 @@
 
 package no.ndla.articleapi.service.converters.contentbrowser
 
-import no.ndla.articleapi.model.domain.ContentFilMeta
+import no.ndla.articleapi.model.domain.{ContentFilMeta, ImportStatus}
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import org.mockito.Mockito._
 import no.ndla.articleapi.model.domain.ContentFilMeta._
@@ -30,7 +30,7 @@ class FilConverterTest extends UnitSuite with TestEnvironment {
 
     when(extractService.getNodeFilMeta(nodeId)).thenReturn(Success(fileMeta))
     when(attachmentStorageService.uploadFileFromUrl(nodeId, fileMeta)).thenReturn(Success(filePath))
-    val Success((result, _, _)) = FilConverter.convert(content, Seq())
+    val Success((result, _, _)) = FilConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     verify(extractService, times(1)).getNodeFilMeta(nodeId)

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/GeneralContentConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/GeneralContentConverterTest.scala
@@ -39,7 +39,7 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
     val content = ContentBrowser(contentString, "nb")
 
     when(extractService.getNodeGeneralContent(nodeId)).thenReturn(Seq(sampleFagstoff1, sampleFagstoff2))
-    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, ImportStatus.empty)
 
     result should equal (sampleFagstoff1.content)
     status.messages.isEmpty should equal (true)
@@ -50,7 +50,7 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
     val content = ContentBrowser(contentString, "nb")
 
     when(extractService.getNodeGeneralContent(nodeId)).thenReturn(Seq())
-    generalContentConverter.convert(content, Seq()).isFailure should be (true)
+    generalContentConverter.convert(content, ImportStatus.empty).isFailure should be (true)
   }
 
   test("That GeneralContentConverter inserts the content if insertion mode is 'collapsed_body'") {
@@ -60,7 +60,7 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
 
     when(extractService.getNodeGeneralContent(nodeId)).thenReturn(Seq(sampleFagstoff1, sampleFagstoff2))
     when(readService.getContentByExternalId(nodeId)).thenReturn(Some(sampleArticle))
-    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, ImportStatus.empty)
 
     result should equal (expectedResult)
     status.messages.isEmpty should equal (true)
@@ -75,7 +75,7 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
 
     when(extractService.getNodeGeneralContent(nodeId)).thenReturn(Seq(sampleFagstoff1, sampleFagstoff2))
     when(readService.getContentByExternalId(nodeId)).thenReturn(Some(sampleArticle))
-    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, ImportStatus.empty)
 
     result should equal (expectedResult)
     status.messages.isEmpty should equal (true)
@@ -89,7 +89,7 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
 
     when(extractService.getNodeGeneralContent(nodeId)).thenReturn(Seq(sampleFagstoff1, sampleFagstoff2))
     when(readService.getContentByExternalId(nodeId)).thenReturn(Some(sampleArticle))
-    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, ImportStatus.empty)
 
     result should equal (expectedResult)
     status.messages.nonEmpty should equal (true)
@@ -104,7 +104,7 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
     when(extractService.getNodeGeneralContent(nodeId)).thenReturn(Seq(sampleFagstoff1, sampleFagstoff2))
     when(readService.getContentByExternalId(nodeId)).thenReturn(Some(sampleArticle))
 
-    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, status)) = generalContentConverter.convert(content, ImportStatus.empty)
 
     result should equal (expectedResult)
     status.messages.nonEmpty should equal (true)
@@ -122,7 +122,7 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
     when(extractConvertStoreContent.processNode(nodeId, ImportStatus(Seq(), Seq(nodeId2)))).thenReturn(Try((TestData.sampleArticleWithByNcSa.copy(id=Some(newNodeid)), ImportStatus(Seq(), Seq(nodeId2, nodeId)))))
 
     val languageContent = sampleContent.copy(content="<div>sample content</div>")
-    val Success((result, _, status)) = generalContentConverter.convert(content, Seq(nodeId2))
+    val Success((result, _, status)) = generalContentConverter.convert(content, ImportStatus(Seq.empty, Seq(nodeId2)))
 
     result should equal(expectedResult)
     status should equal (ImportStatus(List(), List(nodeId2, nodeId)))
@@ -137,6 +137,6 @@ class GeneralContentConverterTest extends UnitSuite with TestEnvironment {
     when(readService.getContentByExternalId(nodeId)).thenReturn(None)
     when(extractConvertStoreContent.processNode(nodeId, ImportStatus(Seq(), Seq(nodeId2)))).thenReturn(Failure(NotFoundException("Node was not found")))
 
-    generalContentConverter.convert(content, Seq(nodeId2)).isFailure should be (true)
+    generalContentConverter.convert(content, ImportStatus(Seq.empty, Seq(nodeId2))).isFailure should be (true)
   }
 }

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/H5PConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/H5PConverterTest.scala
@@ -11,6 +11,7 @@ package no.ndla.articleapi.service.converters.contentbrowser
 
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import no.ndla.articleapi.ArticleApiProperties.resourceHtmlEmbedTag
+import no.ndla.articleapi.model.domain.ImportStatus
 
 import scala.util.Success
 
@@ -22,7 +23,7 @@ class H5PConverterTest extends UnitSuite with TestEnvironment {
 
   test("That contentbrowser strings of type 'h5p_content' returns an iframe") {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-resource="h5p" data-url="//ndla.no/h5p/embed/1234" />"""
-    val Success((result, requiredLibraries, errors)) = H5PConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = H5PConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(0)

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/ImageConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/ImageConverterTest.scala
@@ -9,7 +9,7 @@
 
 package no.ndla.articleapi.service.converters.contentbrowser
 
-import no.ndla.articleapi.model.domain.Author
+import no.ndla.articleapi.model.domain.{Author, ImportStatus}
 import no.ndla.articleapi.integration._
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import no.ndla.articleapi.ArticleApiProperties.resourceHtmlEmbedTag
@@ -35,7 +35,7 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
 
     when(imageApiClient.importOrGetMetaByExternId(nodeId)).thenReturn(Some(image))
 
-    val Success((result, requiredLibraries, errors)) = ImageConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = ImageConverter.convert(content, ImportStatus.empty)
     result should equal (expectedResult)
     errors.messages.length should equal(0)
     requiredLibraries.length should equal(0)
@@ -46,7 +46,7 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-align="" data-alt="$altText" data-caption="" data-resource="image" data-resource_id="1234" data-size="fullbredde" />"""
 
     when(imageApiClient.importOrGetMetaByExternId(nodeId)).thenReturn(Some(image))
-    val Success((result, requiredLibraries, errors)) = ImageConverter.convert(ContentBrowser(contentStringEmptyCaption, "nb"), Seq())
+    val Success((result, requiredLibraries, errors)) = ImageConverter.convert(ContentBrowser(contentStringEmptyCaption, "nb"), ImportStatus.empty)
 
     result should equal (expectedResult)
     errors.messages.length should equal(0)
@@ -57,7 +57,7 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<img src='stock.jpeg' alt='The image with id $nodeId was not not found' />"""
 
     when(imageApiClient.importOrGetMetaByExternId(nodeId)).thenReturn(None)
-    ImageConverter.convert(content, Seq()).isFailure should be (true)
+    ImageConverter.convert(content, ImportStatus.empty).isFailure should be (true)
   }
 
   test("That a the html tag contains an alignment attribute with the correct value") {
@@ -65,7 +65,7 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-align="right" data-alt="$altText" data-caption="$caption" data-resource="image" data-resource_id="1234" data-size="fullbredde" />"""
 
     when(imageApiClient.importOrGetMetaByExternId(nodeId)).thenReturn(Some(image))
-    val Success((result, requiredLibraries, errors)) = ImageConverter.convert(ContentBrowser(contentStringWithLeftMargin, "nb"), Seq())
+    val Success((result, requiredLibraries, errors)) = ImageConverter.convert(ContentBrowser(contentStringWithLeftMargin, "nb"), ImportStatus.empty)
 
     result should equal (expectedResult)
     errors.messages.length should equal(0)

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/JoubelH5PConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/JoubelH5PConverterTest.scala
@@ -11,6 +11,7 @@ package no.ndla.articleapi.service.converters.contentbrowser
 
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import no.ndla.articleapi.ArticleApiProperties.resourceHtmlEmbedTag
+import no.ndla.articleapi.model.domain.ImportStatus
 
 import scala.util.Success
 
@@ -24,7 +25,7 @@ class JoubelH5PConverterTest extends UnitSuite with TestEnvironment {
   test("Contentbrowser strings of type 'h5p_content' returns a h5p embed-resource") {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-resource="h5p" data-url="${JoubelH5PConverter.JoubelH5PBaseUrl}/$joubelH5PIdId" />"""
     val content = ContentBrowser(contentStringWithValidNodeId, "nb")
-    val Success((result, requiredLibraries, errors)) = JoubelH5PConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = JoubelH5PConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(0)
@@ -34,7 +35,7 @@ class JoubelH5PConverterTest extends UnitSuite with TestEnvironment {
   test("H5P nodes with an invalid node id returns an error embed-resource") {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-message="H5P node $invalidNodeId is not yet exported to new H5P service" data-resource="error" />"""
     val content = ContentBrowser(contentStringWithInvalidNodeId, "nb")
-    val Success((result, requiredLibraries, errors)) = JoubelH5PConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = JoubelH5PConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(1)

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/LenkeConverterTest.scala
@@ -12,6 +12,7 @@ package no.ndla.articleapi.service.converters.contentbrowser
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 import no.ndla.articleapi.ArticleApiProperties.resourceHtmlEmbedTag
 import no.ndla.articleapi.integration.MigrationEmbedMeta
+import no.ndla.articleapi.model.domain.ImportStatus
 import no.ndla.articleapi.service.converters.ResourceType
 import org.mockito.Mockito._
 
@@ -37,7 +38,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=$insertion==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val content = ContentBrowser(contentString, "nb")
 
-    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
     result should equal(linkEmbedCode)
     requiredLibraries.length should equal(0)
     errors.messages.length should equal(1)
@@ -49,7 +50,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val content = ContentBrowser(contentString, "nb")
     val expectedResult = """ <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
-    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
     result should equal(expectedResult)
     requiredLibraries.length should equal(0)
     errors.messages.length should equal(0)
@@ -61,7 +62,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val content = ContentBrowser(contentString, "nb")
     val expectedResult = """ <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
-    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
     result should equal(expectedResult)
     requiredLibraries.length should equal(0)
     errors.messages.length should equal(1)
@@ -73,7 +74,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val content = ContentBrowser(contentString, "nb")
     val expectedResult = """ <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
-    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
     result should equal(expectedResult)
     requiredLibraries.length should equal(0)
     errors.messages.length should equal(0)
@@ -85,7 +86,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val content = ContentBrowser(contentString, "nb")
     val expectedResult = s""" <a href="https://www.youtube.com/watch?v=1qN72LEQnaU" rel="noopener noreferrer" target="_blank" title=""> </a>"""
 
-    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     requiredLibraries.length should equal(0)
@@ -99,7 +100,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-nrk-video-id="$nrkVideoId" data-resource="nrk" data-url="$nrkLinkUrl" />"""
 
     when(extractService.getNodeEmbedMeta(nodeId)).thenReturn(Success(MigrationEmbedMeta(Some(nrkLinkUrl), Some(nrkEmbedScript))))
-    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(1)
@@ -118,7 +119,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-height="451" data-resource="${ResourceType.Prezi}" data-url="$preziSrc" data-width="620" />"""
 
     when(extractService.getNodeEmbedMeta(nodeId)).thenReturn(Success(MigrationEmbedMeta(Some(preziUrl), Some(preziEmbedCode))))
-    val Success((result, _, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, _, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(1)
@@ -135,7 +136,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-height="451" data-resource="${ResourceType.Commoncraft}" data-url="$CcraftSrc" data-width="620" />"""
 
     when(extractService.getNodeEmbedMeta(nodeId)).thenReturn(Success(MigrationEmbedMeta(Some(CcraftUrl), Some(CcraftEmbedCode))))
-    val Success((result, _, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, _, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(1)
@@ -152,7 +153,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-height="337px" data-resource="${ResourceType.NdlaFilmIundervisning}" data-url="$NdlaFilmSrc" data-width="632px" />"""
 
     when(extractService.getNodeEmbedMeta(nodeId)).thenReturn(Success(MigrationEmbedMeta(Some(NdlaFilmUrl), Some(NdlaFilmEmbedCode))))
-    val Success((result, _, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, _, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(1)
@@ -169,7 +170,7 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
     val expectedResult = s"""<$resourceHtmlEmbedTag data-height="350px" data-resource="${ResourceType.Kahoot}" data-url="$KahootSrc" data-width="620px" />"""
 
     when(extractService.getNodeEmbedMeta(nodeId)).thenReturn(Success(MigrationEmbedMeta(Some(KahootUrl), Some(KahootEmbedCode))))
-    val Success((result, _, errors)) = LenkeConverter.convert(content, Seq())
+    val Success((result, _, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     errors.messages.length should equal(1)

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/NonExistentNodeConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/NonExistentNodeConverterTest.scala
@@ -9,6 +9,7 @@
 
 package no.ndla.articleapi.service.converters.contentbrowser
 
+import no.ndla.articleapi.model.domain.ImportStatus
 import no.ndla.articleapi.{TestEnvironment, UnitSuite}
 
 class NonExistentNodeConverterTest extends UnitSuite with TestEnvironment {
@@ -17,6 +18,6 @@ class NonExistentNodeConverterTest extends UnitSuite with TestEnvironment {
 
   test("That NonExistentNodeConverter returns a Failure") {
     val content = ContentBrowser(contentString, "nb")
-    NonExistentNodeConverter.convert(content, Seq()).isFailure should be (true)
+    NonExistentNodeConverter.convert(content, ImportStatus.empty).isFailure should be (true)
   }
 }

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterTest.scala
@@ -29,7 +29,7 @@ class VideoConverterTest extends UnitSuite with TestEnvironment {
   test("That VideoConverter converts a ContentBrowser to html code") {
     val content = ContentBrowser(contentString, "nb")
     val expectedResult = s"""<$resourceHtmlEmbedTag data-account="$NDLABrightcoveAccountId" data-caption="" data-player="$NDLABrightcovePlayerId" data-resource="brightcove" data-videoid="ref:${content.get("nid")}" />"""
-    val Success((result, requiredLibraries, _)) = VideoConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, _)) = VideoConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     requiredLibraries.length should equal(1)
@@ -38,7 +38,7 @@ class VideoConverterTest extends UnitSuite with TestEnvironment {
   test("Captions are added as video metadata") {
     val content = ContentBrowser(contentStringWithCaptions, "nb")
     val expectedResult = s"""<$resourceHtmlEmbedTag data-account="$NDLABrightcoveAccountId" data-caption="$caption" data-player="$NDLABrightcovePlayerId" data-resource="brightcove" data-videoid="ref:${content.get("nid")}" />"""
-    val Success((result, requiredLibraries, _)) = VideoConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, _)) = VideoConverter.convert(content, ImportStatus.empty)
 
     result should equal(expectedResult)
     requiredLibraries.length should equal(1)
@@ -50,7 +50,7 @@ class VideoConverterTest extends UnitSuite with TestEnvironment {
 
     when(extractConvertStoreContent.processNode(any[String], any[ImportStatus])).thenReturn(Success(TestData.sampleArticleWithByNcSa, ImportStatus.empty))
 
-    val Success((result, requiredLibraries, _)) = VideoConverter.convert(content, Seq())
+    val Success((result, requiredLibraries, _)) = VideoConverter.convert(content, ImportStatus.empty)
     result should equal(expectedResult)
     requiredLibraries.length should equal(0)
   }

--- a/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/contentbrowser/VideoConverterTest.scala
@@ -48,7 +48,7 @@ class VideoConverterTest extends UnitSuite with TestEnvironment {
     val content = ContentBrowser(contentStringWithInsertionLink, "nb")
     val expectedResult = s"""<$resourceHtmlEmbedTag data-content-id="1" data-link-text="$caption" data-resource="${ResourceType.ContentLink}" />"""
 
-    when(extractConvertStoreContent.processNode(any[String], any[ImportStatus])).thenReturn(Success(TestData.sampleArticleWithByNcSa, ImportStatus.empty))
+    when(extractConvertStoreContent.processNode(nodeId, ImportStatus.empty)).thenReturn(Success(TestData.sampleArticleWithByNcSa, ImportStatus.empty))
 
     val Success((result, requiredLibraries, _)) = VideoConverter.convert(content, ImportStatus.empty)
     result should equal(expectedResult)


### PR DESCRIPTION
* Nytt query-parameter `forceUpdate` som oppdaterer artikkel under import uavhengig om den har blitt menuelt endret eller ikke
* By default force-oppdateres artikkelen **ikke**
* Alle artikler som, på en eller annen måte, lenkes til påvirkes også av `forceUpdate` flagget.
E.i, alle artikler som lenkes til, releaterte artikler osv, blir også force oppdatert dersom hoved-artiklen force-oppdateres