### PR TITLE
#682: Comments in styletags should be removed

### DIFF
--- a/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleapi/service/converters/HTMLCleaner.scala
@@ -156,7 +156,7 @@ trait HTMLCleaner {
       while (i < node.childNodes().size()) {
         val child = node.childNode(i)
 
-        child.nodeName() == "#comment" match {
+        child.nodeName() == "#comment" || child.nodeName() == "#data" match {
           case true => child.remove()
           case false => {
             i += 1

--- a/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/converters/HTMLCleanerTest.scala
@@ -712,4 +712,12 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
     result.content should equal(expectedContent)
   }
 
+  test("Comments in style tag should be removed") {
+    val originalContent = """<section><p>Text here</p><style><!-- This is a weird thing to do --></style></section>"""
+    val expectedContent = """<section><p>Text here</p></section>"""
+
+    val Success((result, _)) = htmlCleaner.convert(TestData.sampleContent.copy(content = originalContent), defaultImportStatus)
+    result.content should equal(expectedContent)
+  }
+
 }


### PR DESCRIPTION
Comments i `style`-tags tolkes av Jsoup som [`#data`](https://jsoup.org/apidocs/org/jsoup/nodes/DataNode.html), og dette oppdateres ikke når du unwrapper `style` tags.