### PR TITLE
#881: Sets executionContext for Futures.

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -9,7 +9,7 @@
 
 package no.ndla.articleapi.controller
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Executors, TimeUnit}
 
 import no.ndla.articleapi.auth.{Role, User}
 import no.ndla.articleapi.model.api.{ArticleIdV2, UpdatedConcept}
@@ -24,7 +24,6 @@ import no.ndla.validation.ValidationException
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.{InternalServerError, NotFound, Ok}
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
@@ -47,6 +46,7 @@ trait InternController {
     protected implicit override val jsonFormats: Formats = DefaultFormats
 
     post("/index") {
+      implicit val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)
       val indexResults = for {
         articleIndex <- Future { articleIndexService.indexDocuments }
         conceptIndex <- Future { conceptIndexService.indexDocuments }

--- a/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
@@ -9,6 +9,8 @@
 
 package no.ndla.articleapi.service.search
 
+import java.util.concurrent.Executors
+
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.articleapi.ArticleApiProperties
 import no.ndla.articleapi.integration.Elastic4sClient
@@ -28,7 +30,7 @@ import com.sksamuel.elastic4s.searches.queries.BoolQueryDefinition
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 trait ArticleSearchService {
@@ -130,6 +132,7 @@ trait ArticleSearchService {
     }
 
     private def scheduleIndexDocuments(): Unit = {
+      implicit val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)
       val f = Future {
         articleIndexService.indexDocuments
       }

--- a/src/main/scala/no/ndla/articleapi/service/search/ConceptSearchService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/ConceptSearchService.scala
@@ -8,6 +8,8 @@
 
 package no.ndla.articleapi.service.search
 
+import java.util.concurrent.Executors
+
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.searches.ScoreMode
 import com.sksamuel.elastic4s.searches.queries.BoolQueryDefinition
@@ -24,7 +26,7 @@ import org.json4s.{DefaultFormats, _}
 import org.json4s.native.JsonMethods._
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 trait ConceptSearchService {
@@ -124,6 +126,7 @@ trait ConceptSearchService {
     }
 
     private def scheduleIndexDocuments() = {
+      implicit val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)
       val f = Future {
         conceptIndexService.indexDocuments
       }


### PR DESCRIPTION
Gets executioncontext from executorservice in multiple places so that we may spawn as many
threads as we please rather than being limited by the global setting (one per cpucore)