### PR TITLE
#1146: Stores all externalIds in database and adds endpoint fetching ids

### DIFF
--- a/src/main/resources/db/migration/V13__ExternalIdAsArray.sql
+++ b/src/main/resources/db/migration/V13__ExternalIdAsArray.sql
@@ -1,0 +1,2 @@
+ALTER TABLE contentdata ALTER external_id TYPE text[] USING ARRAY[external_id];
+ALTER TABLE conceptdata ALTER external_id TYPE text[] USING ARRAY[external_id];

--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -80,6 +80,14 @@ trait InternController {
       }
     }
 
+    get("/external_ids/:external_id") {
+      val externalId = params("external_id")
+      articleRepository.getArticleIdsFromExternalId(externalId) match {
+        case Some(idObject) => idObject
+        case None => NotFound()
+      }
+    }
+
     post("/id/article/allocate/?") {
       authRole.assertHasDraftWritePermission()
 

--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -83,14 +83,14 @@ trait InternController {
     post("/id/article/allocate/?") {
       authRole.assertHasDraftWritePermission()
 
-      val externalId = paramOrNone("external-id")
+      val externalId = paramAsListOfString("external-id")
       val externalSubjectId = paramAsListOfString("external-subject-id")
       ArticleIdV2(writeService.allocateArticleId(externalId, externalSubjectId.toSet))
     }
 
     post("/id/concept/allocate/?") {
       authRole.assertHasDraftWritePermission()
-      val externalId = paramOrNone("external-id")
+      val externalId = paramAsListOfString("external-id")
       ArticleIdV2(writeService.allocateConceptId(externalId))
     }
 

--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -91,15 +91,15 @@ trait InternController {
     post("/id/article/allocate/?") {
       authRole.assertHasDraftWritePermission()
 
-      val externalId = paramAsListOfString("external-id")
+      val externalIds = paramAsListOfString("external-id")
       val externalSubjectId = paramAsListOfString("external-subject-id")
-      ArticleIdV2(writeService.allocateArticleId(externalId, externalSubjectId.toSet))
+      ArticleIdV2(writeService.allocateArticleId(externalIds, externalSubjectId.toSet))
     }
 
     post("/id/concept/allocate/?") {
       authRole.assertHasDraftWritePermission()
-      val externalId = paramAsListOfString("external-id")
-      ArticleIdV2(writeService.allocateConceptId(externalId))
+      val externalIds = paramAsListOfString("external-id")
+      ArticleIdV2(writeService.allocateConceptId(externalIds))
     }
 
     get("/articles") {

--- a/src/main/scala/no/ndla/articleapi/model/domain/package.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/package.scala
@@ -12,7 +12,7 @@ package object domain {
     lang.filter(_.nonEmpty)
   }
 
-  case class ArticleIds(articleId: Long, externalId: Option[String])
+  case class ArticleIds(articleId: Long, externalId: List[String])
 
   def getByLanguage[T](entries: Seq[LanguageField[T]], language: String): Option[T] =
     entries.find(_.language == language).map(_.value)

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -228,6 +228,15 @@ trait ArticleRepository {
       sql"select ${ar.result.*} from ${Article.as(ar)} where ar.document is not NULL and $whereClause".map(Article(ar)).list.apply()
     }
 
+    def getArticleIdsFromExternalId(externalId: String)(implicit session: DBSession = ReadOnlyAutoSession): Option[ArticleIds] = {
+      val ar = Article.syntax("ar")
+      sql"select id, external_id from ${Article.as(ar)} where $externalId=ANY(ar.external_id)".map(rs =>
+        ArticleIds(
+          rs.long("id"),
+          rs.array("external_id").getArray.asInstanceOf[Array[String]].toList
+        )).single.apply
+    }
+
   }
 
 }

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -77,7 +77,7 @@ trait ArticleRepository {
       }
     }
 
-    def insertWithExternalIds(article: Article, externalId: Seq[String], externalSubjectId: Seq[String])(implicit session: DBSession = AutoSession): Article = {
+    def insertWithExternalIds(article: Article, externalIds: Seq[String], externalSubjectId: Seq[String])(implicit session: DBSession = AutoSession): Article = {
       val dataObject = new PGobject()
       dataObject.setType("jsonb")
       dataObject.setValue(write(article))
@@ -85,10 +85,10 @@ trait ArticleRepository {
       val articleId: Long =
         sql"""
              insert into ${Article.table} (external_id, external_subject_id, document)
-             values (ARRAY[${externalId}]::text[], ARRAY[${externalSubjectId}]::text[], ${dataObject})
+             values (ARRAY[${externalIds}]::text[], ARRAY[${externalSubjectId}]::text[], ${dataObject})
           """.updateAndReturnGeneratedKey().apply
 
-      logger.info(s"Inserted article $externalId: $articleId")
+      logger.info(s"Inserted article $externalIds: $articleId")
       article.copy(id = Some(articleId))
     }
 
@@ -118,18 +118,18 @@ trait ArticleRepository {
       articleId
     }
 
-    def allocateArticleIdWithExternalIds(externalId: List[String], externalSubjectId: Set[String])(implicit session: DBSession = AutoSession): Long = {
+    def allocateArticleIdWithExternalIds(externalIds: List[String], externalSubjectId: Set[String])(implicit session: DBSession = AutoSession): Long = {
       val startRevision = 0
 
       val articleId: Long =
         sql"""
              insert into ${Article.table} (external_id, external_subject_id, revision)
-             values (ARRAY[${externalId}]::text[], ARRAY[${externalSubjectId}]::text[], $startRevision)
+             values (ARRAY[${externalIds}]::text[], ARRAY[${externalSubjectId}]::text[], $startRevision)
           """
           .updateAndReturnGeneratedKey()
           .apply
 
-      logger.info(s"Allocated id for article $articleId (external ids ${externalId.mkString(",")})")
+      logger.info(s"Allocated id for article $articleId (external ids ${externalIds.mkString(",")})")
       articleId
     }
 

--- a/src/main/scala/no/ndla/articleapi/repository/ConceptRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ConceptRepository.scala
@@ -26,7 +26,7 @@ trait ConceptRepository {
   class ConceptRepository extends LazyLogging with Repository[Concept] {
     implicit val formats: Formats = org.json4s.DefaultFormats + Concept.JSonSerializer
 
-    def insertWithExternalIds(concept: Concept, externalId: List[String])(implicit session: DBSession = AutoSession): Concept = {
+    def insertWithExternalIds(concept: Concept, externalIds: List[String])(implicit session: DBSession = AutoSession): Concept = {
       val dataObject = new PGobject()
       dataObject.setType("jsonb")
       dataObject.setValue(write(concept))
@@ -34,7 +34,7 @@ trait ConceptRepository {
       val conceptId: Long =
         sql"""
              insert into ${Concept.table} (document, external_id)
-             values ($dataObject, ARRAY[$externalId]::text[])
+             values ($dataObject, ARRAY[$externalIds]::text[])
           """.updateAndReturnGeneratedKey.apply
 
       logger.info(s"Inserted new concept: $conceptId")
@@ -49,18 +49,18 @@ trait ConceptRepository {
       articleId
     }
 
-    def allocateConceptIdWithExternalIds(externalId: List[String])(implicit session: DBSession = AutoSession): Long = {
+    def allocateConceptIdWithExternalIds(externalIds: List[String])(implicit session: DBSession = AutoSession): Long = {
       val startRevision = 0
 
       val conceptId: Long =
         sql"""
             insert into ${Concept.table} (external_id, revision)
-            values (ARRAY[$externalId]::text[], $startRevision)
+            values (ARRAY[$externalIds]::text[], $startRevision)
           """
           .updateAndReturnGeneratedKey()
           .apply
 
-      logger.info(s"Allocated id for concept $conceptId (external id $externalId)")
+      logger.info(s"Allocated id for concept $conceptId (external id $externalIds)")
       conceptId
     }
 

--- a/src/main/scala/no/ndla/articleapi/repository/ConceptRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ConceptRepository.scala
@@ -26,15 +26,19 @@ trait ConceptRepository {
   class ConceptRepository extends LazyLogging with Repository[Concept] {
     implicit val formats: Formats = org.json4s.DefaultFormats + Concept.JSonSerializer
 
-    def insertWithExternalId(concept: Concept, externalId: String)(implicit session: DBSession = AutoSession): Concept = {
+    def insertWithExternalIds(concept: Concept, externalId: List[String])(implicit session: DBSession = AutoSession): Concept = {
       val dataObject = new PGobject()
       dataObject.setType("jsonb")
       dataObject.setValue(write(concept))
 
-      val conceptId: Long = sql"insert into ${Concept.table} (document, external_id) values (${dataObject}, ${externalId})".updateAndReturnGeneratedKey.apply
+      val conceptId: Long =
+        sql"""
+             insert into ${Concept.table} (document, external_id)
+             values ($dataObject, ARRAY[$externalId]::text[])
+          """.updateAndReturnGeneratedKey.apply
 
       logger.info(s"Inserted new concept: $conceptId")
-      concept.copy(id=Some(conceptId))
+      concept.copy(id = Some(conceptId))
     }
 
     def allocateConceptId()(implicit session: DBSession = AutoSession): Long = {
@@ -45,13 +49,19 @@ trait ConceptRepository {
       articleId
     }
 
-    def allocateConceptIdWithExternal(externalId: String)(implicit session: DBSession = AutoSession): Long = {
+    def allocateConceptIdWithExternalIds(externalId: List[String])(implicit session: DBSession = AutoSession): Long = {
       val startRevision = 0
 
-      val articleId: Long = sql"insert into ${Concept.table} (external_id, revision) values (${externalId}, $startRevision)".updateAndReturnGeneratedKey().apply
+      val conceptId: Long =
+        sql"""
+            insert into ${Concept.table} (external_id, revision)
+            values (ARRAY[$externalId]::text[], $startRevision)
+          """
+          .updateAndReturnGeneratedKey()
+          .apply
 
-      logger.info(s"Allocated id for concept $articleId (external id $externalId)")
-      articleId
+      logger.info(s"Allocated id for concept $conceptId (external id $externalId)")
+      conceptId
     }
 
     def updateWithExternalId(concept: Concept, externalId: String)(implicit session: DBSession = AutoSession): Try[Concept] = {
@@ -59,8 +69,8 @@ trait ConceptRepository {
       dataObject.setType("jsonb")
       dataObject.setValue(write(concept))
 
-      Try(sql"update ${Concept.table} set document=${dataObject} where external_id=${externalId}".updateAndReturnGeneratedKey.apply) match {
-        case Success(id) => Success(concept.copy(id=Some(id)))
+      Try(sql"update ${Concept.table} set document=${dataObject} where ${externalId} = any (external_id)".updateAndReturnGeneratedKey.apply) match {
+        case Success(id) => Success(concept.copy(id = Some(id)))
         case Failure(ex) =>
           logger.warn(s"Failed to update concept with external id $externalId: ${ex.getMessage}")
           Failure(ex)
@@ -90,7 +100,7 @@ trait ConceptRepository {
       val conceptId: Long = sql"insert into ${Concept.table} (document) values (${dataObject})".updateAndReturnGeneratedKey.apply
 
       logger.info(s"Inserted new concept: $conceptId")
-      concept.copy(id=Some(conceptId))
+      concept.copy(id = Some(conceptId))
     }
 
     def update(concept: Concept, id: Long)(implicit session: DBSession = AutoSession): Try[Concept] = {
@@ -99,7 +109,7 @@ trait ConceptRepository {
       dataObject.setValue(write(concept))
 
       Try(sql"update ${Concept.table} set document=${dataObject} where id=${id}".updateAndReturnGeneratedKey.apply) match {
-        case Success(id) => Success(concept.copy(id=Some(id)))
+        case Success(id) => Success(concept.copy(id = Some(id)))
         case Failure(ex) =>
           logger.warn(s"Failed to update concept with id $id: ${ex.getMessage}")
           Failure(ex)
@@ -110,10 +120,10 @@ trait ConceptRepository {
       conceptWhere(sqls"co.id=${id.toInt}")
 
     def withExternalId(externalId: String): Option[Concept] =
-      conceptWhere(sqls"co.external_id=$externalId")
+      conceptWhere(sqls"$externalId = any (co.external_id)")
 
     def getIdFromExternalId(externalId: String)(implicit session: DBSession = AutoSession): Option[Long] =
-      sql"select id from ${Concept.table} where external_id=${externalId}".map(rs => rs.long("id")).single.apply()
+      sql"select id from ${Concept.table} where ${externalId} = any(external_id)".map(rs => rs.long("id")).single.apply()
 
     def exists(externalId: String): Boolean =
       getIdFromExternalId(externalId).isDefined
@@ -151,4 +161,5 @@ trait ConceptRepository {
     }
 
   }
+
 }

--- a/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
@@ -321,8 +321,9 @@ trait ConverterService {
       RequiredLibrary(requiredLibs.mediaType, requiredLibs.name, requiredLibs.url)
     }
 
-    private def getLinkToOldNdla(id: Long): Option[String] = {
-      articleRepository.getExternalIdFromId(id).map(createLinkToOldNdla)
+    private def getMainNidUrlToOldNdla(id: Long): Option[String] = {
+      // First nid in externalId's should always be mainNid after import.
+      articleRepository.getExternalIdsFromId(id).map(createLinkToOldNdla).headOption
     }
 
     private def removeUnknownEmbedTagAttributes(html: String): String = {
@@ -353,7 +354,7 @@ trait ConverterService {
 
         Success(api.ArticleV2(
           article.id.get,
-          article.id.flatMap(getLinkToOldNdla),
+          article.id.flatMap(getMainNidUrlToOldNdla),
           article.revision.get,
           title,
           articleContent,

--- a/src/main/scala/no/ndla/articleapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/WriteService.scala
@@ -49,20 +49,21 @@ trait WriteService {
       } yield domainArticle
     }
 
-    def allocateArticleId(externalId: Option[String], externalSubjectIds: Set[String] = Set.empty): Long = {
+    def allocateArticleId(externalId: List[String], externalSubjectIds: Set[String] = Set.empty): Long = {
       val repo = articleRepository
       externalId match {
-        case None => repo.allocateArticleId
-        case Some(nid) => repo.getIdFromExternalId(nid)
-          .getOrElse(repo.allocateArticleIdWithExternal(nid, externalSubjectIds))
+        case Nil => repo.allocateArticleId
+        case mainNid :: restOfNids => repo.getIdFromExternalId(mainNid)
+          .getOrElse(repo.allocateArticleIdWithExternalIds(mainNid :: restOfNids, externalSubjectIds))
       }
     }
 
-    def allocateConceptId(externalId: Option[String]): Long = {
+    def allocateConceptId(externalId: List[String]): Long = {
       val repo = conceptRepository
       externalId match {
-        case None => repo.allocateConceptId
-        case Some(nid) => repo.getIdFromExternalId(nid).getOrElse(repo.allocateConceptIdWithExternal(nid))
+        case Nil => repo.allocateConceptId
+        case mainNid :: restOfNids => repo.getIdFromExternalId(mainNid)
+          .getOrElse(repo.allocateConceptIdWithExternalIds(mainNid :: restOfNids))
       }
     }
 

--- a/src/main/scala/no/ndla/articleapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/WriteService.scala
@@ -49,18 +49,18 @@ trait WriteService {
       } yield domainArticle
     }
 
-    def allocateArticleId(externalId: List[String], externalSubjectIds: Set[String] = Set.empty): Long = {
+    def allocateArticleId(externalIds: List[String], externalSubjectIds: Set[String] = Set.empty): Long = {
       val repo = articleRepository
-      externalId match {
+      externalIds match {
         case Nil => repo.allocateArticleId
         case mainNid :: restOfNids => repo.getIdFromExternalId(mainNid)
           .getOrElse(repo.allocateArticleIdWithExternalIds(mainNid :: restOfNids, externalSubjectIds))
       }
     }
 
-    def allocateConceptId(externalId: List[String]): Long = {
+    def allocateConceptId(externalIds: List[String]): Long = {
       val repo = conceptRepository
-      externalId match {
+      externalIds match {
         case Nil => repo.allocateConceptId
         case mainNid :: restOfNids => repo.getIdFromExternalId(mainNid)
           .getOrElse(repo.allocateConceptIdWithExternalIds(mainNid :: restOfNids))

--- a/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -101,4 +101,12 @@ class ArticleRepositoryTest extends IntegrationSuite with TestEnvironment {
     repository.delete(inserted2)
   }
 
+  test("getArticleIdsFromExternalId should return ArticleIds object with externalIds") {
+    val externalIds = Seq("1", "6010", "6011", "5084", "763", "8881", "1919")
+    val inserted = repository.insertWithExternalIds(sampleArticle, externalIds, Seq.empty)
+
+    repository.getArticleIdsFromExternalId("6011").get.externalId should be(externalIds)
+    repository.delete(inserted.id.get)
+  }
+
 }

--- a/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
@@ -44,38 +44,38 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("toApiArticleV2 converts a domain.Article to an api.ArticleV2") {
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
     service.toApiArticleV2(TestData.sampleDomainArticle, "nb") should equal(Success(TestData.apiArticleV2))
   }
 
   test("that toApiArticleV2 returns sorted supportedLanguages") {
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
     val result = service.toApiArticleV2(TestData.sampleDomainArticle.copy(title = TestData.sampleDomainArticle.title :+ ArticleTitle("hehe", "unknown")), "nb")
     result.get.supportedLanguages should be(Seq("unknown", "nb"))
   }
 
   test("toApiArticleV2 returns None when language is not supported") {
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
     service.toApiArticleV2(TestData.sampleDomainArticle, "someRandomLanguage").isFailure should be(true)
     service.toApiArticleV2(TestData.sampleDomainArticle, "").isFailure should be(true)
   }
 
   test("toApiArticleV2 should always an article if language neutral") {
     val domainArticle = TestData.sampleDomainArticleWithLanguage("unknown")
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
     service.toApiArticleV2(domainArticle, "someRandomLanguage").isSuccess should be(true)
   }
 
   test("toApiArticleV2 should return Failure if article does not exist on the language asked for and is not language neutral") {
     val domainArticle = TestData.sampleDomainArticleWithLanguage("en")
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
     service.toApiArticleV2(domainArticle, "someRandomLanguage").isFailure should be(true)
   }
 
   test("toApiArticleV2 converts a domain.Article to an api.ArticleV2 with Agreement Copyright") {
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
-    val from = DateTime.now().minusDays(5).toDate()
-    val to = DateTime.now().plusDays(10).toDate()
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
+    val from = DateTime.now().minusDays(5).toDate
+    val to = DateTime.now().plusDays(10).toDate
     val agreementCopyright = api.Copyright(
       api.License("gnu", Some("gpl"), None),
       "http://tjohei.com/",
@@ -104,13 +104,13 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("that toApiArticleV2 returns none if article does not exist on language, and fallback is not specified") {
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
     val result = service.toApiArticleV2(TestData.sampleDomainArticle, "en")
     result.isFailure should be (true)
   }
 
   test("That toApiArticleV2 returns article on existing language if fallback is specified even if selected language does not exist") {
-    when(articleRepository.getExternalIdFromId(TestData.articleId)).thenReturn(Some(TestData.externalId))
+    when(articleRepository.getExternalIdsFromId(TestData.articleId)).thenReturn(List(TestData.externalId))
     val result = service.toApiArticleV2(TestData.sampleDomainArticle, "en", fallback = true)
     result.get.title.language should be("nb")
     result.get.title.title should be(TestData.sampleDomainArticle.title.head.title)

--- a/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
@@ -47,7 +47,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     val article = TestData.sampleArticleWithByNcSa.copy(content = Seq(articleContent1), visualElement = Seq(VisualElement(visualElementBefore, "nb")))
 
     when(articleRepository.withId(1)).thenReturn(Option(article))
-    when(articleRepository.getExternalIdFromId(any[Long])(any[DBSession])).thenReturn(Some("54321"))
+    when(articleRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List("54321"))
 
     val expectedResult = converterService.toApiArticleV2(article.copy(content = Seq(expectedArticleContent1), visualElement = Seq(VisualElement(visualElementAfter, "nb"))), "nb")
     readService.withIdV2(1, "nb") should equal(expectedResult)

--- a/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
@@ -35,7 +35,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(articleRepository.withId(articleId)).thenReturn(Option(article))
     when(articleIndexService.indexDocument(any[Article])).thenAnswer((invocation: InvocationOnMock) => Try(invocation.getArgumentAt(0, article.getClass)))
     when(readService.addUrlsOnEmbedResources(any[Article])).thenAnswer((invocation: InvocationOnMock) => invocation.getArgumentAt(0, article.getClass))
-    when(articleRepository.getExternalIdFromId(any[Long])(any[DBSession])).thenReturn(Option("1234"))
+    when(articleRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List("1234"))
     when(authUser.userOrClientid()).thenReturn("ndalId54321")
     when(clock.now()).thenReturn(today)
     when(contentValidator.validateArticle(any[Article], any[Boolean])).thenAnswer((invocation: InvocationOnMock) =>
@@ -50,45 +50,45 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
   test("allocateArticleId should reuse existing id if external id already exists") {
     val id = 1122: Long
     when(articleRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(id))
-    service.allocateArticleId(Some("123123123"), Set.empty) should equal(id)
+    service.allocateArticleId(List("123123123"), Set.empty) should equal(id)
   }
 
   test("allocateArticleId should allocate new id if no external id is supplied or first time use of external id") {
     val id = 1122: Long
     val external = "12312313"
     when(articleRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(None)
-    when(articleRepository.allocateArticleIdWithExternal(any[String], any[Set[String]])(any[DBSession])).thenReturn(id)
-    service.allocateArticleId(Some(external), Set.empty) should equal(id)
+    when(articleRepository.allocateArticleIdWithExternalIds(any[List[String]], any[Set[String]])(any[DBSession])).thenReturn(id)
+    service.allocateArticleId(List(external), Set.empty) should equal(id)
     verify(articleRepository, times(0)).allocateArticleId()
-    verify(articleRepository, times(1)).allocateArticleIdWithExternal(external, Set.empty)
+    verify(articleRepository, times(1)).allocateArticleIdWithExternalIds(List(external), Set.empty)
 
     reset(articleRepository)
     when(articleRepository.allocateArticleId()(any[DBSession])).thenReturn(id)
-    service.allocateArticleId(None, Set.empty) should equal(id)
+    service.allocateArticleId(List.empty, Set.empty) should equal(id)
     verify(articleRepository, times(1)).allocateArticleId()
-    verify(articleRepository, times(0)).allocateArticleIdWithExternal(external, Set.empty)
+    verify(articleRepository, times(0)).allocateArticleIdWithExternalIds(List(external), Set.empty)
   }
 
   test("allocateConceptId should reuse existing id if external id already exists") {
     val id = 1122: Long
     when(conceptRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(Some(id))
-    service.allocateConceptId(Some("123123123")) should equal(id)
+    service.allocateConceptId(List("123123123")) should equal(id)
   }
 
   test("allocateConceptId should allocate new id if no external id is supplied or first time use of external id") {
     val id = 1122: Long
     val external = "12312313"
     when(conceptRepository.getIdFromExternalId(any[String])(any[DBSession])).thenReturn(None)
-    when(conceptRepository.allocateConceptIdWithExternal(any[String])(any[DBSession])).thenReturn(id)
-    service.allocateConceptId(Some(external)) should equal(id)
+    when(conceptRepository.allocateConceptIdWithExternalIds(any[List[String]])(any[DBSession])).thenReturn(id)
+    service.allocateConceptId(List(external)) should equal(id)
     verify(conceptRepository, times(0)).allocateConceptId()
-    verify(conceptRepository, times(1)).allocateConceptIdWithExternal(external)
+    verify(conceptRepository, times(1)).allocateConceptIdWithExternalIds(List(external))
 
     reset(conceptRepository)
     when(conceptRepository.allocateConceptId()(any[DBSession])).thenReturn(id)
-    service.allocateConceptId(None) should equal(id)
+    service.allocateConceptId(List.empty) should equal(id)
     verify(conceptRepository, times(1)).allocateConceptId()
-    verify(conceptRepository, times(0)).allocateConceptIdWithExternal(external)
+    verify(conceptRepository, times(0)).allocateConceptIdWithExternalIds(List(external))
   }
 
 


### PR DESCRIPTION
connects to https://github.com/NDLANO/Issues/issues/1146
First id should always be the main node id.
```
GET /intern/external_ids/170178
{
    "articleId": 1,
    "externalId": [
        "170165",
        "170178"
    ]
}
```