### PR TITLE
Allow empty metadescription

### DIFF
--- a/src/main/scala/db/migration/V24__RemoveDomainFromH5PUrl.scala
+++ b/src/main/scala/db/migration/V24__RemoveDomainFromH5PUrl.scala
@@ -114,14 +114,11 @@ class V24__RemoveDomainFromH5PUrl extends BaseJavaMigration {
   }
 
   def updateContent(contents: JArray, contentType: String): json4s.JValue = {
-    contents.map {
-      case content =>
-        content.mapField {
-          case (`contentType`, JString(html)) => (`contentType`, JString(updateContent(html)))
-          case z                              => z
-        }
-      case y => y
-    }
+    contents.map(content =>
+      content.mapField {
+        case (`contentType`, JString(html)) => (`contentType`, JString(updateContent(html)))
+        case z                              => z
+    })
   }
 
   private[migration] def convertArticleUpdate(document: String): String = {

--- a/src/main/scala/no/ndla/articleapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/WriteService.scala
@@ -49,7 +49,7 @@ trait WriteService {
 
       val validationResult =
         if (useSoftValidation) {
-          (strictValidationResult, contentValidator.softValidateArticle(article)) match {
+          (strictValidationResult, contentValidator.softValidateArticle(article, isImported = useImportValidation)) match {
             case (Failure(strictEx: ValidationException), Success(art)) =>
               val strictErrors = strictEx.errors
                 .map(msg => {

--- a/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -33,12 +33,14 @@ trait ContentValidator {
     private val NoHtmlValidator = new TextValidator(allowHtml = false)
     private val HtmlValidator = new TextValidator(allowHtml = true)
 
-    def softValidateArticle(article: Article): Try[Article] = {
+    def softValidateArticle(article: Article, isImported: Boolean): Try[Article] = {
+      val metaValidation =
+        if (isImported) None else validateNonEmpty("metaDescription", article.metaDescription)
       val validationErrors =
         validateArticleType(article.articleType) ++
           validateNonEmpty("content", article.content) ++
           validateNonEmpty("title", article.title) ++
-          validateNonEmpty("metaDescription", article.metaDescription)
+          metaValidation
 
       if (validationErrors.isEmpty) {
         Success(article)

--- a/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
+++ b/src/main/scala/no/ndla/articleapi/validation/ContentValidator.scala
@@ -129,15 +129,13 @@ trait ContentValidator {
     private def validateMetaDescription(contents: Seq[ArticleMetaDescription],
                                         allowUnknownLanguage: Boolean,
                                         allowEmpty: Boolean): Seq[ValidationMessage] = {
+      val nonEmptyValidation = if (allowEmpty) None else validateNonEmpty("metaDescription", contents)
       val validations = contents.flatMap(content => {
         val field = s"metaDescription.${content.language}"
         NoHtmlValidator.validate(field, content.content).toList ++
           validateLanguage("metaDescription.language", content.language, allowUnknownLanguage)
       })
-      if (allowEmpty) {
-        return validations
-      }
-      validations ++ validateNonEmpty("metaDescription", contents)
+      validations ++ nonEmptyValidation
     }
 
     private def validateTitle(titles: Seq[LanguageField[String]],

--- a/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -338,7 +338,8 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
       false)
 
     val softRes = contentValidator.softValidateArticle(
-      TestData.sampleArticleWithByNcSa.copy(metaImage = Seq(ArticleMetaImage("", "alt-text", "nb"))))
+      TestData.sampleArticleWithByNcSa.copy(metaImage = Seq(ArticleMetaImage("", "alt-text", "nb"))),
+      false)
 
     strictRes.errors.length should be(1)
     strictRes.errors.head.field should be("metaImageId")

--- a/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
+++ b/src/test/scala/no/ndla/articleapi/validation/ContentValidatorTest.scala
@@ -300,6 +300,15 @@ class ContentValidatorTest extends UnitSuite with TestEnvironment {
       ))
   }
 
+  test("imported articles should pass validation for missing metaDescription") {
+    val res0 = contentValidator.validateArticle(
+      TestData.sampleArticleWithByNcSa.copy(metaDescription = Seq.empty),
+      allowUnknownLanguage = true,
+      isImported = true
+    )
+    res0.isSuccess should be(true)
+  }
+
   test("validation should fail if there are no tags for any languages") {
     val Failure(res: ValidationException) =
       contentValidator.validateArticle(TestData.sampleArticleWithByNcSa.copy(tags = Seq()),


### PR DESCRIPTION
Publisering av artikler via script feiler dersom metaDescription er tom. Disse artiklene blei importert uten metadescription og blei publisert som en del av importen, så det burde være mogeleg å publisere dei ved å spesifisere import-flagget.