### PR TITLE
#2180: Adds simple partial publish for grepCodes

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -373,7 +373,8 @@ trait ArticleControllerV2 {
             asHeaderParam(correlationId),
             asPathParam(articleId),
             asQueryParam(language),
-            asQueryParam(fallback)
+            asQueryParam(fallback),
+            bodyParam[PartialPublishArticle]
         )
           responseMessages (response404, response500))
     ) {

--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -385,7 +385,6 @@ trait ArticleControllerV2 {
       val language = paramOrDefault(this.language.paramName, Language.AllLanguages)
       val fallback = booleanOrDefault(this.fallback.paramName, default = false)
 
-
       writeService.partialUpdate(articleId, partialUpdateBody, language, fallback) match {
         case Failure(ex)         => errorHandler(ex)
         case Success(apiArticle) => Ok(apiArticle)

--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -362,5 +362,35 @@ trait ArticleControllerV2 {
         case None           => NotFound()
       }
     }
+
+    patch(
+      "/partial-publish/:article_id",
+      operation(
+        apiOperation[ArticleV2]("partialPublish")
+          summary "Publish metadata of article directly without affecting rest of article."
+          description "Publish metadata of article directly without affecting rest of article."
+          parameters (
+            asHeaderParam(correlationId),
+            asPathParam(articleId),
+            asQueryParam(language),
+            asQueryParam(fallback)
+        )
+          responseMessages (response404, response500))
+    ) {
+
+      authRole.assertHasWritePermission()
+
+      val articleId = long(this.articleId.paramName)
+      val partialUpdateBody = extract[PartialPublishArticle](request.body)
+      val language = paramOrDefault(this.language.paramName, Language.AllLanguages)
+      val fallback = booleanOrDefault(this.fallback.paramName, default = false)
+
+
+      writeService.partialUpdate(articleId, partialUpdateBody, language, fallback) match {
+        case Failure(ex)         => errorHandler(ex)
+        case Success(apiArticle) => Ok(apiArticle)
+      }
+
+    }
   }
 }

--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -129,7 +129,7 @@ trait InternController {
 
     post("/article/:id") {
       authRole.assertHasWritePermission()
-      val externalIds = paramAsListOfLong("external-id")
+      val externalIds = paramAsListOfString("external-id")
       val useImportValidation = booleanOrDefault("use-import-validation", default = false)
       val useSoftValidation = booleanOrDefault("use-soft-validation", default = false)
       val article = extract[Article](request.body)

--- a/src/main/scala/no/ndla/articleapi/model/api/PartialPublishArticle.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/PartialPublishArticle.scala
@@ -12,6 +12,7 @@ import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
 
+// format: off
 @ApiModel(description = "Partial data about article to publish independently")
 case class PartialPublishArticle(
     @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Option[Seq[String]]

--- a/src/main/scala/no/ndla/articleapi/model/api/PartialPublishArticle.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/PartialPublishArticle.scala
@@ -1,0 +1,18 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2020 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.articleapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+
+import scala.annotation.meta.field
+
+@ApiModel(description = "Partial data about article to publish independently")
+case class PartialPublishArticle(
+    @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Option[Seq[String]]
+)


### PR DESCRIPTION
Jeg elsker ikke at revision ender opp med å mismatche draft-api når vi gjør sånne ting som det her, men er kanskje vanskelig å unngå.