### PR TITLE
Make trailing slash optional for article dump endpoint

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -110,7 +110,7 @@ trait InternController {
       readService.getArticlesByPage(pageNo, pageSize, lang, fallback)
     }
 
-    get("/dump/article") {
+    get("/dump/article/?") {
       // Dumps Domain articles
       val pageNo = intOrDefault("page", 1)
       val pageSize = intOrDefault("page-size", 250)


### PR DESCRIPTION
Gjør det enklere i scriptet siden de andre apiene også støtter trailing slash på dumping