### PR TITLE
#2329: Keeps all published versions in database

### DIFF
--- a/src/main/resources/db/migration/V26__AddArticleId.sql
+++ b/src/main/resources/db/migration/V26__AddArticleId.sql
@@ -1,0 +1,6 @@
+-- Add article_id so id is still unique while versioning
+ALTER TABLE contentdata ADD column article_id bigint not null default 0;
+UPDATE contentdata SET article_id = id;
+
+-- Update contentdata id sequence since inserts have been using determined ids for a while and are _very_ likely out of date
+SELECT setval('contentdata_id_seq', (SELECT MAX(id) FROM contentdata) + 1);

--- a/src/main/scala/db/migration/R__SetArticleLanguageFromTaxonomy.scala
+++ b/src/main/scala/db/migration/R__SetArticleLanguageFromTaxonomy.scala
@@ -136,6 +136,7 @@ class R__SetArticleLanguageFromTaxonomy extends BaseJavaMigration {
       .map(Article.fromResultSet(ar))
       .single()
       .apply()
+      .flatten
   }
 
   def convertArticleLanguage(oldArticle: Option[Article], externalTags: Seq[ArticleTag]): Option[Article] = {

--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -71,7 +71,8 @@ trait ArticleControllerV2 {
     private val pageNo = Param[Option[Int]]("page", "The page number of the search hits to display.")
     private val pageSize = Param[Option[Int]]("page-size", "The number of search hits to display for each page.")
     private val articleId = Param[Long]("article_id", "Id of the article that is to be fecthed.")
-    private val revision = Param[Option[Int]]("revision", "Revision of article to fetch. If not provided the current revision is returned.")
+    private val revision =
+      Param[Option[Int]]("revision", "Revision of article to fetch. If not provided the current revision is returned.")
     private val size =
       Param[Option[Int]](
         "size",

--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -71,6 +71,7 @@ trait ArticleControllerV2 {
     private val pageNo = Param[Option[Int]]("page", "The page number of the search hits to display.")
     private val pageSize = Param[Option[Int]]("page-size", "The number of search hits to display for each page.")
     private val articleId = Param[Long]("article_id", "Id of the article that is to be fecthed.")
+    private val revision = Param[Option[Int]]("revision", "Revision of article to fetch. If not provided the current revision is returned.")
     private val size =
       Param[Option[Int]](
         "size",
@@ -341,15 +342,17 @@ trait ArticleControllerV2 {
             asHeaderParam(correlationId),
             asPathParam(articleId),
             asQueryParam(language),
-            asQueryParam(fallback)
+            asQueryParam(fallback),
+            asQueryParam(revision)
           )
           .responseMessages(response404, response500))
     ) {
       val articleId = long(this.articleId.paramName)
       val language = paramOrDefault(this.language.paramName, Language.AllLanguages)
       val fallback = booleanOrDefault(this.fallback.paramName, default = false)
+      val revision = intOrNone(this.revision.paramName)
 
-      readService.withIdV2(articleId, language, fallback) match {
+      readService.withIdV2(articleId, language, fallback, revision) match {
         case Success(article) => article
         case Failure(ex)      => errorHandler(ex)
       }

--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -376,6 +376,25 @@ trait ArticleControllerV2 {
     }
 
     get(
+      "/:article_id/revisions",
+      operation(
+        apiOperation[List[Int]]("getRevisionsForArticle")
+          .summary("Fetch list of existing revisions for article-id")
+          .description("Fetch list of existing revisions for article-id")
+          .parameters(
+            asHeaderParam(correlationId),
+            asPathParam(articleId),
+          )
+          .responseMessages(response404, response500))
+    ) {
+      val articleId = long(this.articleId.paramName)
+      readService.getRevisions(articleId) match {
+        case Failure(ex)   => errorHandler(ex)
+        case Success(revs) => Ok(revs)
+      }
+    }
+
+    get(
       "/external_id/:deprecated_node_id",
       operation(
         apiOperation[ArticleIdV2]("getInternalIdByExternalId")
@@ -441,7 +460,6 @@ trait ArticleControllerV2 {
         case Failure(ex)         => errorHandler(ex)
         case Success(apiArticle) => Ok(apiArticle)
       }
-
     }
   }
 }

--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -151,7 +151,8 @@ trait InternController {
 
     post("/article/:id/unpublish/") {
       authRole.assertHasWritePermission()
-      writeService.unpublishArticle(long("id")) match {
+      val revision = intOrNone("revision")
+      writeService.unpublishArticle(long("id"), revision) match {
         case Success(a)  => a
         case Failure(ex) => errorHandler(ex)
       }

--- a/src/main/scala/no/ndla/articleapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/InternController.scala
@@ -143,7 +143,8 @@ trait InternController {
 
     delete("/article/:id/") {
       authRole.assertHasWritePermission()
-      writeService.deleteArticle(long("id")) match {
+      val revision = intOrNone("revision")
+      writeService.deleteArticle(long("id"), revision) match {
         case Success(a)  => a
         case Failure(ex) => errorHandler(ex)
       }

--- a/src/main/scala/no/ndla/articleapi/model/api/Article.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/Article.scala
@@ -35,5 +35,6 @@ case class ArticleV2(
     @(ApiModelProperty @field)(description = "When the article was last published") published: Date,
     @(ApiModelProperty @field)(description = "The type of article this is. Possible values are topic-article,standard") articleType: String,
     @(ApiModelProperty @field)(description = "The languages this article supports") supportedLanguages: Seq[String],
-    @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Seq[String])
+    @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Seq[String]
+)
 // format: on

--- a/src/main/scala/no/ndla/articleapi/model/api/Article.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/Article.scala
@@ -14,6 +14,7 @@ import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
 
+// format: off
 @ApiModel(description = "Information about the article")
 case class ArticleV2(
     @(ApiModelProperty @field)(description = "The unique id of the article") id: Long,
@@ -23,12 +24,10 @@ case class ArticleV2(
     @(ApiModelProperty @field)(description = "The content of the article in available languages") content: ArticleContentV2,
     @(ApiModelProperty @field)(description = "Describes the copyright information for the article") copyright: Copyright,
     @(ApiModelProperty @field)(description = "Searchable tags for the article") tags: ArticleTag,
-    @(ApiModelProperty @field)(description = "Required libraries in order to render the article") requiredLibraries: Seq[
-      RequiredLibrary],
+    @(ApiModelProperty @field)(description = "Required libraries in order to render the article") requiredLibraries: Seq[RequiredLibrary],
     @(ApiModelProperty @field)(description = "A visual element article") visualElement: Option[VisualElement],
     @(ApiModelProperty @field)(description = "A meta image for the article") metaImage: Option[ArticleMetaImage],
-    @(ApiModelProperty @field)(description = "An introduction for the article") introduction: Option[
-      ArticleIntroduction],
+    @(ApiModelProperty @field)(description = "An introduction for the article") introduction: Option[ArticleIntroduction],
     @(ApiModelProperty @field)(description = "Meta description for the article") metaDescription: ArticleMetaDescription,
     @(ApiModelProperty @field)(description = "When the article was created") created: Date,
     @(ApiModelProperty @field)(description = "When the article was last updated") updated: Date,
@@ -36,5 +35,5 @@ case class ArticleV2(
     @(ApiModelProperty @field)(description = "When the article was last published") published: Date,
     @(ApiModelProperty @field)(description = "The type of article this is. Possible values are topic-article,standard") articleType: String,
     @(ApiModelProperty @field)(description = "The languages this article supports") supportedLanguages: Seq[String],
-    @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Seq[
-      String])
+    @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Seq[String])
+// format: on

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -36,19 +36,18 @@ trait ArticleRepository {
       Try {
         sql"""update ${Article.table}
               set document=$dataObject,
-                  external_id=ARRAY[$externalIds]::text[],
-                  revision=${article.revision}
-              where id=${article.id}
+                  external_id=ARRAY[$externalIds]::text[]
+              where article_id=${article.id} and revision=${article.revision}
           """.update().apply()
       } match {
         case Success(count) if count == 1 =>
           logger.info(s"Updated article ${article.id}")
           Success(article)
         case Success(_) =>
-          logger.info(s"No article with id ${article.id} exists, creating...")
+          logger.info(s"No article with id ${article.id} and revision ${article.revision} exists, creating...")
           Try {
             sql"""
-                  insert into ${Article.table} (id, document, external_id, revision)
+                  insert into ${Article.table} (article_id, document, external_id, revision)
                   values (${article.id}, $dataObject, ARRAY[$externalIds]::text[], ${article.revision})
               """.updateAndReturnGeneratedKey().apply()
           }.map(_ => article)
@@ -57,8 +56,14 @@ trait ArticleRepository {
       }
     }
 
-    def unpublish(articleId: Long)(implicit session: DBSession = AutoSession): Try[Long] = {
-      val numRows = sql"update ${Article.table} set document=null where id=$articleId".update().apply()
+    def unpublishMaxRevision(articleId: Long)(implicit session: DBSession = AutoSession): Try[Long] = {
+      val numRows =
+        sql"""
+             update ${Article.table}
+             set document=null
+             where article_id=$articleId
+             and revision=(select max(revision) from ${Article.table} where article_id=${articleId})
+           """.update().apply()
       if (numRows == 1) {
         Success(articleId)
       } else {
@@ -66,8 +71,29 @@ trait ArticleRepository {
       }
     }
 
+    def unpublish(articleId: Long, revision: Int)(implicit session: DBSession = AutoSession): Try[Long] = {
+      val numRows =
+        sql"""
+             update ${Article.table}
+             set document=null
+             where article_id=$articleId
+             and revision=$revision
+           """.update().apply()
+      if (numRows == 1) {
+        Success(articleId)
+      } else {
+        Failure(NotFoundException(s"Article with id $articleId does not exist"))
+      }
+    }
+
+    // TODO: What do we do? Delete all of them?
     def delete(articleId: Long)(implicit session: DBSession = AutoSession): Try[Long] = {
-      val numRows = sql"delete from ${Article.table} where id = $articleId".update().apply()
+      val numRows =
+        sql"""
+             delete from ${Article.table}
+             where article_id = $articleId
+             and revision=(select max(revision) from ${Article.table} where article_id=${articleId})
+           """.update().apply()
       if (numRows == 1) {
         Success(articleId)
       } else {
@@ -76,13 +102,26 @@ trait ArticleRepository {
       }
     }
 
-    def withId(articleId: Long): Option[Article] = articleWhere(sqls"ar.id=${articleId.toInt}")
+    def withId(articleId: Long): Option[Article] =
+      articleWhere(
+        sqls"""
+              ar.article_id=${articleId.toInt}
+              ORDER BY revision
+              DESC LIMIT 1
+              """
+      )
 
     def withExternalId(externalId: String): Option[Article] = articleWhere(sqls"$externalId = any (ar.external_id)")
 
     def getIdFromExternalId(externalId: String)(implicit session: DBSession = AutoSession): Option[Long] = {
-      sql"select id from ${Article.table} where $externalId = any(external_id)"
-        .map(rs => rs.long("id"))
+      sql"""
+           select article_id
+           from ${Article.table}
+           where $externalId = any(external_id)
+           order by revision desc
+           limit 1
+         """
+        .map(rs => rs.long("article_id"))
         .single()
         .apply()
     }
@@ -95,7 +134,13 @@ trait ArticleRepository {
     }
 
     def getExternalIdsFromId(id: Long)(implicit session: DBSession = AutoSession): List[String] = {
-      sql"select external_id from ${Article.table} where id=${id.toInt}"
+      sql"""
+           select external_id
+           from ${Article.table}
+           where article_id=${id.toInt}
+           order by revision desc
+           limit 1
+         """
         .map(externalIdsFromResultSet)
         .single()
         .apply()
@@ -103,11 +148,11 @@ trait ArticleRepository {
     }
 
     def getAllIds(implicit session: DBSession = AutoSession): Seq[ArticleIds] = {
-      sql"select id, external_id from ${Article.table}"
+      sql"select article_id, external_id from ${Article.table}"
         .map(
           rs =>
             ArticleIds(
-              rs.long("id"),
+              rs.long("article_id"),
               externalIdsFromResultSet(rs)
           ))
         .list()
@@ -115,7 +160,11 @@ trait ArticleRepository {
     }
 
     def articleCount(implicit session: DBSession = AutoSession): Long = {
-      sql"select count(*) from ${Article.table} where document is not NULL"
+      sql"""
+           select count(distinct article_id)
+           from ${Article.table}
+           where document is not NULL
+         """
         .map(rs => rs.long("count"))
         .single()
         .apply()
@@ -124,10 +173,22 @@ trait ArticleRepository {
 
     def getArticlesByPage(pageSize: Int, offset: Int)(implicit session: DBSession = AutoSession): Seq[Article] = {
       val ar = Article.syntax("ar")
-      sql"select ${ar.result.*} from ${Article.as(ar)} where document is not NULL offset $offset limit $pageSize"
+      sql"""
+           select *
+           from (select
+                   ${ar.result.*},
+                   ${ar.revision} as revision,
+                   max(revision) over (partition by article_id) as max_revision
+                 from ${Article.as(ar)}
+                 where document is not NULL) _
+           where revision = max_revision
+           offset $offset
+           limit $pageSize
+      """
         .map(Article.fromResultSet(ar))
         .list()
         .apply()
+        .flatten
     }
 
     def allTags(implicit session: DBSession = AutoSession): Seq[ArticleTag] = {
@@ -152,7 +213,7 @@ trait ArticleRepository {
       val sanitizedLanguage = language.replaceAll("%", "")
       val langOrAll = if (sanitizedLanguage == "all" || sanitizedLanguage == "") "%" else sanitizedLanguage
 
-      val tags = sql"""select tags from 
+      val tags = sql"""select tags from
               (select distinct JSONB_ARRAY_ELEMENTS_TEXT(tagObj->'tags') tags from
               (select JSONB_ARRAY_ELEMENTS(document#>'{tags}') tagObj from ${Article.table}) _
               where tagObj->>'language' like ${langOrAll}
@@ -167,7 +228,7 @@ trait ArticleRepository {
 
       val tagsCount =
         sql"""
-              select count(*) from 
+              select count(*) from
               (select distinct JSONB_ARRAY_ELEMENTS_TEXT(tagObj->'tags') tags from
               (select JSONB_ARRAY_ELEMENTS(document#>'{tags}') tagObj from ${Article.table}) _
               where tagObj->>'language' like  ${langOrAll}) all_tags
@@ -183,7 +244,7 @@ trait ArticleRepository {
     }
 
     override def minMaxId(implicit session: DBSession = AutoSession): (Long, Long) = {
-      sql"select coalesce(MIN(id),0) as mi, coalesce(MAX(id),0) as ma from ${Article.table}"
+      sql"select coalesce(MIN(article_id),0) as mi, coalesce(MAX(article_id),0) as ma from ${Article.table}"
         .map(rs => {
           (rs.long("mi"), rs.long("ma"))
         })
@@ -195,34 +256,45 @@ trait ArticleRepository {
     }
 
     override def documentsWithIdBetween(min: Long, max: Long): List[Article] =
-      articlesWhere(sqls"ar.id between $min and $max").toList
+      articlesWhere(sqls"ar.article_id between $min and $max").toList
 
     private def articleWhere(whereClause: SQLSyntax)(
         implicit session: DBSession = ReadOnlyAutoSession): Option[Article] = {
       val ar = Article.syntax("ar")
-      sql"select ${ar.result.*} from ${Article.as(ar)} where ar.document is not NULL and $whereClause"
+      sql"""
+           select ${ar.result.*}
+           from ${Article.as(ar)}
+           where $whereClause
+         """
         .map(Article.fromResultSet(ar))
         .single()
         .apply()
+        .flatten
     }
 
     private def articlesWhere(whereClause: SQLSyntax)(
         implicit session: DBSession = ReadOnlyAutoSession): Seq[Article] = {
       val ar = Article.syntax("ar")
-      sql"select ${ar.result.*} from ${Article.as(ar)} where ar.document is not NULL and $whereClause"
+      sql"""
+        select ${ar.result.*}
+        from ${Article.as(ar)}
+        where ar.document is not NULL
+        and $whereClause
+         """
         .map(Article.fromResultSet(ar))
         .list()
         .apply()
+        .flatten
     }
 
     def getArticleIdsFromExternalId(externalId: String)(
         implicit session: DBSession = ReadOnlyAutoSession): Option[ArticleIds] = {
       val ar = Article.syntax("ar")
-      sql"select id, external_id from ${Article.as(ar)} where $externalId=ANY(ar.external_id)"
+      sql"select article_id, external_id from ${Article.as(ar)} where $externalId=ANY(ar.external_id)"
         .map(
           rs =>
             ArticleIds(
-              rs.long("id"),
+              rs.long("article_id"),
               externalIdsFromResultSet(rs)
           ))
         .single()

--- a/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
+++ b/src/main/scala/no/ndla/articleapi/repository/ArticleRepository.scala
@@ -149,6 +149,18 @@ trait ArticleRepository {
         .apply()
     }
 
+    def getRevisions(articleId: Long)(implicit session: DBSession = ReadOnlyAutoSession): Seq[Int] = {
+      sql"""
+            select revision
+            from ${Article.table}
+            where article_id=${articleId}
+            and document is not NULL;
+         """
+        .map(rs => rs.int("revision"))
+        .list()
+        .apply()
+    }
+
     private def externalIdsFromResultSet(wrappedResultSet: WrappedResultSet): List[String] = {
       Option(wrappedResultSet.array("external_id"))
         .map(_.getArray.asInstanceOf[Array[String]])

--- a/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
@@ -339,7 +339,7 @@ trait ConverterService {
             article.published,
             article.articleType,
             supportedLanguages,
-            article.grepCodes,
+            article.grepCodes
           ))
       } else {
         Failure(

--- a/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -10,21 +10,20 @@ package no.ndla.articleapi.service
 
 import io.lemonlabs.uri.{Path, Url}
 import no.ndla.articleapi.ArticleApiProperties.externalApiUrls
-import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import no.ndla.articleapi.caching.MemoizeAutoRenew
-import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
 import no.ndla.articleapi.model.api
 import no.ndla.articleapi.model.api.NotFoundException
-import no.ndla.articleapi.model.domain._
 import no.ndla.articleapi.model.domain.Language._
+import no.ndla.articleapi.model.domain._
 import no.ndla.articleapi.repository.ArticleRepository
-import no.ndla.articleapi.ArticleApiProperties.Domain
+import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
+import no.ndla.validation.HtmlTagRules.{jsoupDocumentToString, stringToJsoupDocument}
 import no.ndla.validation.{ResourceType, TagAttributes}
 import org.jsoup.nodes.Element
 
-import scala.math.max
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Try}
+import scala.math.max
+import scala.util.{Failure, Success, Try}
 
 trait ReadService {
   this: ArticleRepository with ConverterService =>
@@ -131,6 +130,13 @@ trait ReadService {
       }
     }
 
+    def getRevisions(articleId: Long): Try[Seq[Int]] = {
+      articleRepository.getRevisions(articleId) match {
+        case Nil       => Failure(NotFoundException(s"Could not find any revisions for article with id $articleId"))
+        case revisions => Success(revisions)
+      }
+    }
+
     class MostFrequentOccurencesList(list: Seq[String]) {
       // Create a map where the key is a list entry, and the value is the number of occurences of this entry in the list
       private[this] val listToNumOccurencesMap: Map[String, Int] = list.groupBy(identity).view.mapValues(_.size).toMap
@@ -152,7 +158,6 @@ trait ReadService {
 
     def getArticleIdsByExternalId(externalId: String): Option[api.ArticleIds] =
       articleRepository.getArticleIdsFromExternalId(externalId).map(converterService.toApiArticleIds)
-
   }
 
 }

--- a/src/main/scala/no/ndla/articleapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/WriteService.scala
@@ -114,7 +114,7 @@ trait WriteService {
     def deleteArticle(id: Long, revision: Option[Int]): Try[api.ArticleIdV2] = {
       val deleted = revision match {
         case Some(rev) => articleRepository.delete(id, rev)
-        case None => articleRepository.deleteMaxRevision(id)
+        case None      => articleRepository.deleteMaxRevision(id)
       }
 
       deleted

--- a/src/main/scala/no/ndla/articleapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/WriteService.scala
@@ -99,9 +99,13 @@ trait WriteService {
       }
     }
 
-    def unpublishArticle(id: Long): Try[api.ArticleIdV2] = {
-      articleRepository
-        .unpublish(id)
+    def unpublishArticle(id: Long, revision: Option[Int]): Try[api.ArticleIdV2] = {
+      val updated = revision match {
+        case Some(rev) => articleRepository.unpublish(id, rev)
+        case None      => articleRepository.unpublishMaxRevision(id)
+      }
+
+      updated
         .flatMap(articleIndexService.deleteDocument)
         .map(searchApiClient.deleteArticle)
         .map(api.ArticleIdV2)

--- a/src/main/scala/no/ndla/articleapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/WriteService.scala
@@ -111,9 +111,13 @@ trait WriteService {
         .map(api.ArticleIdV2)
     }
 
-    def deleteArticle(id: Long): Try[api.ArticleIdV2] = {
-      articleRepository
-        .delete(id)
+    def deleteArticle(id: Long, revision: Option[Int]): Try[api.ArticleIdV2] = {
+      val deleted = revision match {
+        case Some(rev) => articleRepository.delete(id, rev)
+        case None => articleRepository.deleteMaxRevision(id)
+      }
+
+      deleted
         .flatMap(articleIndexService.deleteDocument)
         .map(searchApiClient.deleteArticle)
         .map(api.ArticleIdV2)

--- a/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -12,6 +12,8 @@ import no.ndla.articleapi.model.api._
 import no.ndla.articleapi.model.domain._
 import no.ndla.articleapi.model.search.SearchResult
 import no.ndla.articleapi.{ArticleSwagger, TestData, TestEnvironment, UnitSuite}
+import no.ndla.validation.{ValidationException, ValidationMessage}
+import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatra.test.scalatest.ScalatraFunSuite
@@ -170,6 +172,18 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     get("/test/tag-search/") {
       status should equal(200)
     }
+  }
+
+  test("That parsing articleId with and without revision works as expected") {
+    controller.parseArticleIdAndRevision("urn:article:15") should be((Success(15), None))
+    controller.parseArticleIdAndRevision("urn:article:15#10") should be((Success(15), Some(10)))
+    controller.parseArticleIdAndRevision("15") should be((Success(15), None))
+    controller.parseArticleIdAndRevision("15#100") should be((Success(15), Some(100)))
+
+    val (failed, Some(100)) = controller.parseArticleIdAndRevision("#100")
+    failed.isFailure should be(true)
+    val (failed2, None) = controller.parseArticleIdAndRevision("")
+    failed2.isFailure should be(true)
   }
 
 }

--- a/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -51,11 +51,11 @@ class ArticleRepositoryTest
 
   override def beforeEach(): Unit = {
     repository = new ArticleRepository
-    if (databaseIsAvailable) repository.getAllIds().foreach(articleId => repository.delete(articleId.articleId))
+    if (databaseIsAvailable) repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
   }
 
   override def afterEach(): Unit =
-    if (databaseIsAvailable) repository.getAllIds().foreach(articleId => repository.delete(articleId.articleId))
+    if (databaseIsAvailable) repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
 
   test("getAllIds returns a list with all ids in the database") {
     assume(databaseIsAvailable, "Database is unavailable")
@@ -84,7 +84,7 @@ class ArticleRepositoryTest
     val inserted = repository.updateArticleFromDraftApi(sampleArticle, externalIds)
 
     repository.getArticleIdsFromExternalId("6011").get.externalId should be(externalIds)
-    repository.delete(inserted.get.id.get)
+    repository.deleteMaxRevision(inserted.get.id.get)
   }
 
   test("updateArticleFromDraftApi should update all columns with data from draft-api") {
@@ -114,8 +114,8 @@ class ArticleRepositoryTest
     val result2 = repository.getExternalIdsFromId(idWithoutExternals.get.id.get)
     result2 should be(List.empty)
 
-    repository.delete(idWithExternals.get.id.get)
-    repository.delete(idWithoutExternals.get.id.get)
+    repository.deleteMaxRevision(idWithExternals.get.id.get)
+    repository.deleteMaxRevision(idWithoutExternals.get.id.get)
   }
 
   test("updating with a valid article with a that is not in database will be recreated") {
@@ -125,14 +125,14 @@ class ArticleRepositoryTest
     val x = repository.updateArticleFromDraftApi(article, List.empty)
     x.isSuccess should be(true)
 
-    repository.delete(x.get.id.get)
+    repository.deleteMaxRevision(x.get.id.get)
   }
 
   test("deleting article should ignore missing articles") {
     assume(databaseIsAvailable, "Database is unavailable")
     val article = TestData.sampleDomainArticle.copy(id = Some(Integer.MAX_VALUE))
 
-    val deletedId = repository.delete(article.id.get)
+    val deletedId = repository.deleteMaxRevision(article.id.get)
     deletedId.get should be(Integer.MAX_VALUE)
   }
 

--- a/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
+++ b/src/test/scala/no/ndla/articleapi/repository/ArticleRepositoryTest.scala
@@ -51,11 +51,13 @@ class ArticleRepositoryTest
 
   override def beforeEach(): Unit = {
     repository = new ArticleRepository
-    if (databaseIsAvailable) repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
+    if (databaseIsAvailable)
+      repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
   }
 
   override def afterEach(): Unit =
-    if (databaseIsAvailable) repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
+    if (databaseIsAvailable)
+      repository.getAllIds().foreach(articleId => repository.deleteMaxRevision(articleId.articleId))
 
   test("getAllIds returns a list with all ids in the database") {
     assume(databaseIsAvailable, "Database is unavailable")

--- a/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
@@ -95,7 +95,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     reset(articleIndexService, searchApiClient)
     val articleIdToUnpublish = 11
 
-    when(articleRepository.delete(any[Long])(any[DBSession])).thenReturn(Success(articleIdToUnpublish))
+    when(articleRepository.deleteMaxRevision(any[Long])(any[DBSession])).thenReturn(Success(articleIdToUnpublish))
     when(articleIndexService.deleteDocument(any[Long])).thenReturn(Success(articleIdToUnpublish))
     when(searchApiClient.deleteArticle(any[Long])).thenReturn(articleIdToUnpublish)
 

--- a/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
@@ -81,11 +81,11 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     reset(articleIndexService, searchApiClient)
     val articleIdToUnpublish = 11
 
-    when(articleRepository.unpublish(any[Long])(any[DBSession])).thenReturn(Success(articleIdToUnpublish))
+    when(articleRepository.unpublishMaxRevision(any[Long])(any[DBSession])).thenReturn(Success(articleIdToUnpublish))
     when(articleIndexService.deleteDocument(any[Long])).thenReturn(Success(articleIdToUnpublish))
     when(searchApiClient.deleteArticle(any[Long])).thenReturn(articleIdToUnpublish)
 
-    service.unpublishArticle(articleIdToUnpublish)
+    service.unpublishArticle(articleIdToUnpublish, None)
 
     verify(articleIndexService, times(1)).deleteDocument(any[Long])
     verify(searchApiClient, times(1)).deleteArticle(any[Long])

--- a/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/WriteServiceTest.scala
@@ -99,7 +99,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     when(articleIndexService.deleteDocument(any[Long])).thenReturn(Success(articleIdToUnpublish))
     when(searchApiClient.deleteArticle(any[Long])).thenReturn(articleIdToUnpublish)
 
-    service.deleteArticle(articleIdToUnpublish)
+    service.deleteArticle(articleIdToUnpublish, None)
 
     verify(articleIndexService, times(1)).deleteDocument(any[Long])
     verify(searchApiClient, times(1)).deleteArticle(any[Long])


### PR DESCRIPTION
Relates to NDLANO/Issues#2329
- Kan hende spesifikk revisjon med `/article-api/v2/articles/1?revision=1`
  - Hvis den ikke blir oppgitt så velger den siste
- Dersom siste revision er `unpublished`/`null` i databasen så får man 404 dersom man ikke spør om en spesifikk revision.
- unpublish- og delete-endepunktene velger siste revision by default, men støtter også spesifikk revision med `?revision=1`

