### PR TITLE
Only spawn pact suite when running pact tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - find $HOME/.sbt -name "*.lock" -delete
 
     - name: "Pact provider verification tests"
-      script: sbt ++$TRAVIS_SCALA_VERSION "pact:testOnly -- -n PactProviderTest"
+      script: sbt ++$TRAVIS_SCALA_VERSION "pact:testOnly *consumerdrivencontracts*"
       dist: focal
       language: scala
       scala: 2.13.3

--- a/src/test/scala/no/ndla/articleapi/consumerdrivencontracts/ArticleApiProviderCDCTest.scala
+++ b/src/test/scala/no/ndla/articleapi/consumerdrivencontracts/ArticleApiProviderCDCTest.scala
@@ -30,6 +30,7 @@ object PactProviderTest extends Tag("PactProviderTest")
 
 class ArticleApiProviderCDCTest
     extends IntegrationSuite(EnableElasticsearchContainer = true, EnablePostgresContainer = true)
+    with UnitSuite
     with TestEnvironment {
   override val dataSource = testDataSource.get
 


### PR DESCRIPTION
Skal forhåpentligvis fikse minneproblemene på travis under pact-testene.

Kjører bare test suiter som heter noe med *consumerdrivencontracts* (Som er det pakkenavnet hvor pact-testene ligger).
Da slipper vi å spawne docker-containere (Som bruker masse minne) for alle testsuiter vi hopper over tester i dersom vi bruker tags slik som tidligere.

Grunnen til at det ikke skjer ved vanlig sbt test er fordi vi ikke hopper over testene så containere rekker å bli slettet før vi har for mange samtidig til at minnet blir fullt.