### PR TITLE
Relates to NDLANO/Issues#2434

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -118,14 +118,14 @@ trait ArticleControllerV2 {
     private def scrollSearchOr(scrollId: Option[String], language: String, fallback: Boolean)(
         orFunction: => Any): Any = {
       scrollId match {
-        case Some(scroll) =>
+        case Some(scroll) if !InitialScrollContextKeywords.contains(scroll) =>
           articleSearchService.scroll(scroll, language, fallback) match {
             case Success(scrollResult) =>
               val responseHeader = scrollResult.scrollId.map(i => this.scrollId.paramName -> i).toMap
               Ok(searchConverterService.asApiSearchResultV2(scrollResult), headers = responseHeader)
             case Failure(ex) => errorHandler(ex)
           }
-        case None => orFunction
+        case _ => orFunction
       }
     }
 

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -261,4 +261,18 @@ object TestData {
 
   val sampleApiTagsSearchResult = api.TagsSearchResult(10, 1, 1, "nb", Seq("a", "b"))
 
+  val testSettings = SearchSettings(
+    query = None,
+    withIdIn = List(),
+    language = Language.DefaultLanguage,
+    license = None,
+    page = 1,
+    pageSize = 10,
+    sort = Sort.ByIdAsc,
+    articleTypes = Seq.empty,
+    fallback = false,
+    grepCodes = Seq.empty,
+    shouldScroll = false
+  )
+
 }

--- a/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -186,4 +186,30 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     failed2.isFailure should be(true)
   }
 
+  test("That initial search-context doesn't scroll") {
+    reset(articleSearchService)
+
+    val expectedSettings = TestData.testSettings.copy(
+      language = "all",
+      articleTypes = List("standard", "topic-article"),
+      shouldScroll = true
+    )
+
+    val result = SearchResult[ArticleSummaryV2](
+      totalCount = 0,
+      page = None,
+      pageSize = 10,
+      language = "all",
+      results = Seq.empty,
+      scrollId = Some("heiheihei")
+    )
+    when(articleSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(result))
+
+    get("/test/?search-context=initial") {
+      status should be(200)
+      verify(articleSearchService, times(1)).matchingQuery(expectedSettings)
+      verify(articleSearchService, times(0)).scroll(any[String], any[String], any[Boolean])
+    }
+  }
+
 }

--- a/src/test/scala/no/ndla/articleapi/service/search/ArticleSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/search/ArticleSearchServiceTest.scala
@@ -14,6 +14,7 @@ import no.ndla.articleapi.integration.{Elastic4sClientFactory, NdlaE4sClient}
 import no.ndla.articleapi.model.api
 import no.ndla.articleapi.model.domain._
 import no.ndla.mapping.License.{CC_BY_NC_SA, Copyrighted, PublicDomain}
+import no.ndla.articleapi.TestData.testSettings
 import no.ndla.scalatestsuite.IntegrationSuite
 import org.joda.time.DateTime
 import org.scalatest.Outcome
@@ -224,20 +225,6 @@ class ArticleSearchServiceTest extends IntegrationSuite(EnableElasticsearchConta
     val expectedStartAt = (page - 1) * DefaultPageSize
     articleSearchService.getStartAtAndNumResults(page, DefaultPageSize) should equal((expectedStartAt, DefaultPageSize))
   }
-
-  val testSettings = SearchSettings(
-    query = None,
-    withIdIn = List(),
-    language = Language.DefaultLanguage,
-    license = None,
-    page = 1,
-    pageSize = 10,
-    sort = Sort.ByIdAsc,
-    articleTypes = Seq.empty,
-    fallback = false,
-    grepCodes = Seq.empty,
-    shouldScroll = false
-  )
 
   test("searching should return only articles of a given type if a type filter is specified") {
     val Success(results) =


### PR DESCRIPTION
Fikser så søk med search-context=initial (og de andre) fungerer som forventet og returnerer en search-context header
Søk uten search-context returnerer ingenting