### PR TITLE
2448 related content as article metadata

### DIFF
--- a/src/main/scala/no/ndla/articleapi/model/api/Article.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/Article.scala
@@ -9,7 +9,6 @@
 package no.ndla.articleapi.model.api
 
 import java.util.Date
-
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 
 import scala.annotation.meta.field
@@ -37,6 +36,7 @@ case class ArticleV2(
     @(ApiModelProperty @field)(description = "The languages this article supports") supportedLanguages: Seq[String],
     @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Seq[String],
     @(ApiModelProperty @field)(description = "A list of conceptIds connected to the article") conceptIds: Seq[Long],
-    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: String
+    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: String,
+    @(ApiModelProperty @field)(description = "A list of content related to the article") relatedContent: Seq[RelatedContent]
 )
 // format: on

--- a/src/main/scala/no/ndla/articleapi/model/api/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/RelatedContentLink.scala
@@ -1,0 +1,16 @@
+/*
+ * Part of NDLA article_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+import scala.annotation.meta.field
+
+@ApiModel(description = "Information about a library required to render the article")
+case class RelatedContentLink(
+    @(ApiModelProperty @field)(description = "The type of the library. E.g. CSS or JavaScript") title: String,
+    @(ApiModelProperty @field)(description = "The full url to where the library can be downloaded") url: String)

--- a/src/main/scala/no/ndla/articleapi/model/api/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/RelatedContentLink.scala
@@ -10,7 +10,7 @@ package no.ndla.articleapi.model.api
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 import scala.annotation.meta.field
 
-@ApiModel(description = "Information about a library required to render the article")
+@ApiModel(description = "External link related to the article")
 case class RelatedContentLink(
-    @(ApiModelProperty @field)(description = "The type of the library. E.g. CSS or JavaScript") title: String,
-    @(ApiModelProperty @field)(description = "The full url to where the library can be downloaded") url: String)
+    @(ApiModelProperty @field)(description = "Title of the article") title: String,
+    @(ApiModelProperty @field)(description = "The url to where the article can be viewed") url: String)

--- a/src/main/scala/no/ndla/articleapi/model/api/package.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/package.scala
@@ -1,0 +1,12 @@
+/*
+ * Part of NDLA article_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.model
+
+package object api {
+  type RelatedContent = Either[api.RelatedContentLink, Long];
+}

--- a/src/main/scala/no/ndla/articleapi/model/domain/Content.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/Content.scala
@@ -40,7 +40,8 @@ case class Article(id: Option[Long],
                    articleType: String,
                    grepCodes: Seq[String],
                    conceptIds: Seq[Long],
-                   availability: Availability.Value = Availability.everyone)
+                   availability: Availability.Value = Availability.everyone,
+                   relatedContent: Seq[RelatedContent])
     extends Content
 
 object Article extends SQLSyntaxSupport[Article] {

--- a/src/main/scala/no/ndla/articleapi/model/domain/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/RelatedContentLink.scala
@@ -1,0 +1,11 @@
+/*
+ * Part of NDLA article_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.articleapi.model.domain
+
+case class RelatedContentLink(title: String, url: String)

--- a/src/main/scala/no/ndla/articleapi/model/domain/package.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/package.scala
@@ -13,5 +13,7 @@ package object domain {
     lang.filter(_.nonEmpty)
   }
 
+  type RelatedContent = Either[RelatedContentLink, Long]
+
   case class ArticleIds(articleId: Long, externalId: List[String])
 }

--- a/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ConverterService.scala
@@ -13,7 +13,7 @@ import com.typesafe.scalalogging.LazyLogging
 import no.ndla.articleapi.ArticleApiProperties._
 import no.ndla.articleapi.auth.User
 import no.ndla.articleapi.integration.DraftApiClient
-import no.ndla.articleapi.model.api
+import no.ndla.articleapi.model.{api, domain}
 import no.ndla.articleapi.model.api.{ArticleSummaryV2, ImportException, NotFoundException, PartialPublishArticle}
 import no.ndla.articleapi.model.domain.Language._
 import no.ndla.articleapi.model.domain._
@@ -382,7 +382,8 @@ trait ConverterService {
             supportedLanguages,
             article.grepCodes,
             article.conceptIds,
-            availability = article.availability.toString
+            availability = article.availability.toString,
+            article.relatedContent.map(toApiRelatedContent)
           ))
       } else {
         Failure(
@@ -400,6 +401,14 @@ trait ConverterService {
         content.content,
         content.language
       )
+    }
+
+    def toApiRelatedContent(relatedContent: domain.RelatedContent): api.RelatedContent = {
+      relatedContent match {
+        case Left(x)  => Left(api.RelatedContentLink(url = x.url, title = x.title))
+        case Right(x) => Right(x)
+      }
+
     }
 
     def toApiCopyright(copyright: Copyright): api.Copyright = {

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -68,7 +68,8 @@ object TestData {
     supportedLanguages = Seq("nb"),
     grepCodes = Seq.empty,
     conceptIds = Seq.empty,
-    availability = Availability.everyone.toString
+    availability = Availability.everyone.toString,
+    relatedContent = Seq.empty
   )
 
   val apiArticleV2 = api.ArticleV2(
@@ -103,7 +104,8 @@ object TestData {
     Seq("nb"),
     Seq("COMPCODE1"),
     Seq(1),
-    availability = Availability.everyone.toString
+    availability = Availability.everyone.toString,
+    relatedContent = Seq.empty
   )
 
   val sampleArticleWithPublicDomain = Article(
@@ -125,7 +127,8 @@ object TestData {
     ArticleType.Standard.toString,
     Seq("COMPCODE1"),
     Seq(1),
-    availability = Availability.everyone
+    availability = Availability.everyone,
+    relatedContent = Seq.empty
   )
 
   val sampleDomainArticle = Article(
@@ -147,7 +150,8 @@ object TestData {
     ArticleType.Standard.toString,
     Seq("COMPCODE1"),
     Seq(1),
-    availability = Availability.everyone
+    availability = Availability.everyone,
+    relatedContent = Seq.empty
   )
 
   val sampleDomainArticle2 = Article(
@@ -169,7 +173,8 @@ object TestData {
     ArticleType.Standard.toString,
     Seq("COMPCODE1"),
     Seq(1),
-    availability = Availability.everyone
+    availability = Availability.everyone,
+    relatedContent = Seq.empty
   )
 
   val sampleArticleWithByNcSa: Article = sampleArticleWithPublicDomain.copy(copyright = byNcSaCopyright)
@@ -202,7 +207,8 @@ object TestData {
     ArticleType.Standard.toString,
     Seq(),
     Seq(),
-    availability = Availability.everyone
+    availability = Availability.everyone,
+    relatedContent = Seq.empty
   )
 
   val apiArticleWithHtmlFaultV2 = api.ArticleV2(
@@ -233,7 +239,8 @@ object TestData {
     Seq("en"),
     Seq.empty,
     Seq.empty,
-    availability = Availability.everyone.toString
+    availability = Availability.everyone.toString,
+    relatedContent = Seq.empty
   )
 
   val (nodeId, nodeId2) = ("1234", "4321")
@@ -263,7 +270,8 @@ object TestData {
       ArticleType.Standard.toString,
       Seq(),
       Seq(),
-      availability = Availability.everyone
+      availability = Availability.everyone,
+      relatedContent = Seq.empty
     )
   }
 


### PR DESCRIPTION
Relatert til NDLANO/Issues#2448

Se gjerne på https://github.com/NDLANO/draft-api/pull/253 samtidig.

Legger til et nytt felt i artikkel med relatert innhold. Dette skal på mange måter være likt som relaterte forklaringer som er en liste med id-er. Listen over relatert innhold skal også kunne innholde eksterne lenker (tittel+url).