### PR TITLE
getArticleDomainDump add url on embed resource

### DIFF
--- a/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -82,7 +82,8 @@ trait ReadService {
 
     def getArticleDomainDump(pageNo: Int, pageSize: Int): api.ArticleDomainDump = {
       val (safePageNo, safePageSize) = (max(pageNo, 1), max(pageSize, 0))
-      val results = articleRepository.getArticlesByPage(safePageSize, (safePageNo - 1) * safePageSize)
+      val results =
+        articleRepository.getArticlesByPage(safePageSize, (safePageNo - 1) * safePageSize).map(addUrlsOnEmbedResources)
 
       api.ArticleDomainDump(articleRepository.articleCount, pageNo, pageSize, results)
     }


### PR DESCRIPTION
Se diskusjon NDLANO/Issues#2483.

Sørger for at embeds får riktig base-url (feks h5p-staging.ndla.no i stedet for h5p.ndla.no)