### PR TITLE
#2609: Filter response based on access with FEIDE credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 .bloop/
 .metals/
 project/metals.sbt
-
+.vscode/

--- a/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
+++ b/src/main/scala/no/ndla/articleapi/ComponentRegistry.scala
@@ -30,6 +30,7 @@ object ComponentRegistry
     with Elastic4sClient
     with DraftApiClient
     with SearchApiClient
+    with FeideApiClient
     with ArticleSearchService
     with IndexService
     with ArticleIndexService
@@ -71,6 +72,7 @@ object ComponentRegistry
   var e4sClient: NdlaE4sClient = Elastic4sClientFactory.getClient()
   lazy val draftApiClient = new DraftApiClient
   lazy val searchApiClient = new SearchApiClient
+  lazy val feideApiClient = new FeideApiClient
 
   lazy val clock = new SystemClock
   lazy val authRole = new AuthRole

--- a/src/main/scala/no/ndla/articleapi/integration/FeideApiClient.scala
+++ b/src/main/scala/no/ndla/articleapi/integration/FeideApiClient.scala
@@ -1,0 +1,87 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2019 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.articleapi.integration
+
+import com.typesafe.scalalogging.LazyLogging
+
+import no.ndla.articleapi.ArticleApiProperties.SearchHost
+import no.ndla.articleapi.model.domain.{Article, ArticleType}
+import no.ndla.articleapi.service.ConverterService
+import no.ndla.network.NdlaClient
+import no.ndla.network.model.HttpRequestException
+import org.json4s.{DefaultFormats, Formats}
+import org.json4s.ext.EnumNameSerializer
+import org.json4s.native.JsonMethods
+import org.json4s.native.Serialization.write
+import scalaj.http.{Http, HttpRequest, HttpResponse}
+
+import java.util.concurrent.Executors
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.util.{Failure, Success, Try}
+
+case class FeideExtendedUserInfo(
+    displayName: String,
+    eduPersonAffiliation: Seq[String],
+    eduPersonPrimaryAffiliation: String
+) {
+  def isStudent: Boolean = this.eduPersonAffiliation.contains("student")
+
+  def isTeacher: Boolean = {
+    this.eduPersonPrimaryAffiliation.contains("staff") ||
+    this.eduPersonPrimaryAffiliation.contains("faculty") ||
+    this.eduPersonPrimaryAffiliation.contains("employee")
+  }
+}
+
+trait FeideApiClient {
+  this: NdlaClient with ConverterService =>
+  val feideApiClient: FeideApiClient
+
+  class FeideApiClient extends LazyLogging {
+
+    private val userInfoEndpoint = "https://api.dataporten.no/userinfo/v1/userinfo"
+
+    private val feideTimeout = 1000 * 30
+
+    def getUser(accessToken: String): Try[FeideExtendedUserInfo] = {
+      val request =
+        Http(userInfoEndpoint)
+          .timeout(feideTimeout, feideTimeout)
+          .header("Authorization", s"Bearer $accessToken")
+
+      implicit val formats = DefaultFormats
+
+      for {
+        response <- doRequest(request)
+        parsed <- parseResponse[FeideExtendedUserInfo](response)
+      } yield parsed
+    }
+
+    private def parseResponse[T](response: HttpResponse[String])(implicit mf: Manifest[T], formats: Formats): Try[T] = {
+      Try(JsonMethods.parse(response.body).camelizeKeys.extract[T]) match {
+        case Success(extracted) => Success(extracted)
+        case Failure(ex) =>
+          logger.error("Could not parse response from feide.", ex)
+          Failure(new HttpRequestException(s"Could not parse response ${response.body}", Some(response)))
+      }
+    }
+
+    private def doRequest(request: HttpRequest): Try[HttpResponse[String]] = {
+      Try(request.asString).flatMap(response => {
+        if (response.isError) {
+          Failure(new HttpRequestException(
+            s"Received error ${response.code} ${response.statusLine} when calling ${request.url}. Body was ${response.body}",
+            Some(response)))
+        } else {
+          Success(response)
+        }
+      })
+    }
+  }
+
+}

--- a/src/main/scala/no/ndla/articleapi/integration/FeideApiClient.scala
+++ b/src/main/scala/no/ndla/articleapi/integration/FeideApiClient.scala
@@ -1,6 +1,6 @@
 /*
- * Part of NDLA draft-api.
- * Copyright (C) 2019 NDLA
+ * Part of NDLA article-api.
+ * Copyright (C) 2021 NDLA
  *
  * See LICENSE
  */
@@ -8,20 +8,14 @@
 package no.ndla.articleapi.integration
 
 import com.typesafe.scalalogging.LazyLogging
-
-import no.ndla.articleapi.ArticleApiProperties.SearchHost
-import no.ndla.articleapi.model.domain.{Article, ArticleType}
+import no.ndla.articleapi.model.domain.Availability
 import no.ndla.articleapi.service.ConverterService
 import no.ndla.network.NdlaClient
 import no.ndla.network.model.HttpRequestException
-import org.json4s.{DefaultFormats, Formats}
-import org.json4s.ext.EnumNameSerializer
 import org.json4s.native.JsonMethods
-import org.json4s.native.Serialization.write
+import org.json4s.{DefaultFormats, Formats}
 import scalaj.http.{Http, HttpRequest, HttpResponse}
 
-import java.util.concurrent.Executors
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.util.{Failure, Success, Try}
 
 case class FeideExtendedUserInfo(
@@ -35,6 +29,23 @@ case class FeideExtendedUserInfo(
     this.eduPersonPrimaryAffiliation.contains("staff") ||
     this.eduPersonPrimaryAffiliation.contains("faculty") ||
     this.eduPersonPrimaryAffiliation.contains("employee")
+  }
+
+  def availabilities: Seq[Availability.Value] = {
+    if (this.isTeacher) {
+      Seq(
+        Availability.everyone,
+        Availability.teacher,
+        Availability.student
+      )
+    } else if (this.isStudent) {
+      Seq(
+        Availability.everyone,
+        Availability.student
+      )
+    } else {
+      Seq.empty
+    }
   }
 }
 

--- a/src/main/scala/no/ndla/articleapi/integration/FeideApiClient.scala
+++ b/src/main/scala/no/ndla/articleapi/integration/FeideApiClient.scala
@@ -26,9 +26,9 @@ case class FeideExtendedUserInfo(
   def isStudent: Boolean = this.eduPersonAffiliation.contains("student")
 
   def isTeacher: Boolean = {
-    this.eduPersonPrimaryAffiliation.contains("staff") ||
-    this.eduPersonPrimaryAffiliation.contains("faculty") ||
-    this.eduPersonPrimaryAffiliation.contains("employee")
+    this.eduPersonAffiliation.contains("staff") ||
+    this.eduPersonAffiliation.contains("faculty") ||
+    this.eduPersonAffiliation.contains("employee")
   }
 
   def availabilities: Seq[Availability.Value] = {

--- a/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
@@ -59,7 +59,7 @@ case class NotFoundException(message: String, supportedLanguages: Seq[String] = 
     extends RuntimeException(message)
 case class ImportException(message: String) extends RuntimeException(message)
 
-class AccessDeniedException(message: String) extends RuntimeException(message)
+case class AccessDeniedException(message: String) extends RuntimeException(message)
 class ImportExceptions(val message: String, val errors: Seq[Throwable]) extends RuntimeException(message)
 class ConfigurationException(message: String) extends RuntimeException(message)
 case class SearchException(message: String) extends RuntimeException(message)

--- a/src/main/scala/no/ndla/articleapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/SearchSettings.scala
@@ -19,5 +19,6 @@ case class SearchSettings(
     articleTypes: Seq[String],
     fallback: Boolean,
     grepCodes: Seq[String],
-    shouldScroll: Boolean
+    shouldScroll: Boolean,
+    availability: Seq[Availability.Value]
 )

--- a/src/main/scala/no/ndla/articleapi/model/search/SearchableArticle.scala
+++ b/src/main/scala/no/ndla/articleapi/model/search/SearchableArticle.scala
@@ -25,5 +25,6 @@ case class SearchableArticle(
     authors: Seq[String],
     articleType: String,
     defaultTitle: Option[String],
-    grepCodes: Seq[String]
+    grepCodes: Seq[String],
+    availability: String
 )

--- a/src/main/scala/no/ndla/articleapi/service/search/ArticleIndexService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/ArticleIndexService.scala
@@ -41,6 +41,7 @@ trait ArticleIndexService {
           keywordField("defaultTitle"),
           dateField("lastUpdated"),
           keywordField("license"),
+          keywordField("availability"),
           textField("authors").fielddata(true),
           textField("articleType").analyzer("keyword"),
           nestedField("metaImage").fields(

--- a/src/main/scala/no/ndla/articleapi/service/search/SearchConverterService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/SearchConverterService.scala
@@ -53,7 +53,8 @@ trait SearchConverterService {
           .map(_.name) ++ articleWithAgreement.copyright.rightsholders.map(_.name),
         articleType = articleWithAgreement.articleType,
         defaultTitle = defaultTitle.map(t => t.title),
-        grepCodes = articleWithAgreement.grepCodes
+        grepCodes = articleWithAgreement.grepCodes,
+        availability = articleWithAgreement.availability.toString
       )
     }
 

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -288,7 +288,8 @@ object TestData {
     articleTypes = Seq.empty,
     fallback = false,
     grepCodes = Seq.empty,
-    shouldScroll = false
+    shouldScroll = false,
+    availability = Seq.empty
   )
 
 }

--- a/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
+++ b/src/test/scala/no/ndla/articleapi/TestEnvironment.scala
@@ -36,6 +36,7 @@ trait TestEnvironment
     with MockitoSugar
     with DraftApiClient
     with SearchApiClient
+    with FeideApiClient
     with ConverterService
     with NdlaClient
     with SearchConverterService
@@ -67,6 +68,7 @@ trait TestEnvironment
   var e4sClient = mock[NdlaE4sClient]
   val draftApiClient = mock[DraftApiClient]
   val searchApiClient = mock[SearchApiClient]
+  val feideApiClient = mock[FeideApiClient]
 
   val clock = mock[SystemClock]
   val authUser = mock[AuthUser]

--- a/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -91,7 +91,8 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
         ArticleType.all,
         fallback = false,
         grepCodes = Seq.empty,
-        shouldScroll = false
+        shouldScroll = false,
+        availability = Seq.empty
       )
 
       verify(articleSearchService, times(1)).matchingQuery(expectedSettings)

--- a/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -72,33 +72,6 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     }
   }
 
-  test("GET / should use size of id-list as page-size if defined") {
-    val searchMock = mock[SearchResult[ArticleSummaryV2]]
-    when(searchMock.scrollId).thenReturn(None)
-    when(articleSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(searchMock))
-
-    get("/test/", "ids" -> "1,2,3,4", "page-size" -> "10", "language" -> "nb") {
-      status should equal(200)
-
-      val expectedSettings = SearchSettings(
-        None,
-        List(1, 2, 3, 4),
-        Language.DefaultLanguage,
-        None,
-        1,
-        4,
-        Sort.ByIdAsc,
-        ArticleType.all,
-        fallback = false,
-        grepCodes = Seq.empty,
-        shouldScroll = false,
-        availability = Seq.empty
-      )
-
-      verify(articleSearchService, times(1)).matchingQuery(expectedSettings)
-    }
-  }
-
   test("That scrollId is in header, and not in body") {
     val scrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
@@ -110,7 +83,8 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       Seq.empty[ArticleSummaryV2],
       Some(scrollId)
     )
-    when(articleSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(searchResponse))
+    when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any))
+      .thenReturn(Success(searchResponse))
 
     get(s"/test/") {
       status should be(200)
@@ -120,7 +94,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   }
 
   test("That scrolling uses scroll and not searches normally") {
-    reset(articleSearchService)
+    reset(articleSearchService, readService)
     val scrollId =
       "DnF1ZXJ5VGhlbkZldGNoCgAAAAAAAAC1Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAthYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALcWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC4Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuRYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAALsWLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC9Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFEAAAAAAAAAuhYtY2VPYWFvRFQ5aWNSbzRFYVZSTEhRAAAAAAAAAL4WLWNlT2Fhb0RUOWljUm80RWFWUkxIUQAAAAAAAAC8Fi1jZU9hYW9EVDlpY1JvNEVhVlJMSFE="
     val searchResponse = SearchResult[ArticleSummaryV2](
@@ -139,6 +113,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     }
 
     verify(articleSearchService, times(0)).matchingQuery(any[SearchSettings])
+    verify(readService, times(0)).search(any, any, any, any, any, any, any, any, any, any, any, any)
     verify(articleSearchService, times(1)).scroll(eqTo(scrollId), any[String], any[Boolean])
   }
 
@@ -187,13 +162,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   }
 
   test("That initial search-context doesn't scroll") {
-    reset(articleSearchService)
-
-    val expectedSettings = TestData.testSettings.copy(
-      language = "all",
-      articleTypes = List("standard", "topic-article"),
-      shouldScroll = true
-    )
+    reset(articleSearchService, readService)
 
     val result = SearchResult[ArticleSummaryV2](
       totalCount = 0,
@@ -203,11 +172,24 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       results = Seq.empty,
       scrollId = Some("heiheihei")
     )
-    when(articleSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(result))
+    when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any)).thenReturn(Success(result))
 
     get("/test/?search-context=initial") {
       status should be(200)
-      verify(articleSearchService, times(1)).matchingQuery(expectedSettings)
+      verify(readService, times(1)).search(
+        query = any,
+        sort = any,
+        language = eqTo("all"),
+        license = any,
+        page = any,
+        pageSize = any,
+        idList = any,
+        articleTypesFilter = any,
+        fallback = any,
+        grepCodes = any,
+        shouldScroll = eqTo(true),
+        feideAccessToken = any
+      )
       verify(articleSearchService, times(0)).scroll(any[String], any[String], any[Boolean])
     }
   }

--- a/src/test/scala/no/ndla/articleapi/model/search/SearchableArticleSerializerTest.scala
+++ b/src/test/scala/no/ndla/articleapi/model/search/SearchableArticleSerializerTest.scala
@@ -1,7 +1,7 @@
 package no.ndla.articleapi.model.search
 
 import no.ndla.articleapi._
-import no.ndla.articleapi.model.domain.ArticleMetaImage
+import no.ndla.articleapi.model.domain.{ArticleMetaImage, Availability}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.json4s.Formats
 import org.json4s.native.Serialization.{read, writePretty}
@@ -26,7 +26,8 @@ class SearchableArticleSerializerTest extends UnitSuite with TestEnvironment {
     authors = Seq("Jonas Natty"),
     articleType = "standard",
     defaultTitle = Some("tjuppidu"),
-    grepCodes = Seq("testelitt", "testemye")
+    grepCodes = Seq("testelitt", "testemye"),
+    availability = Availability.everyone.toString
   )
 
   test("That deserialization and serialization of SearchableArticle works as expected") {

--- a/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ConverterServiceTest.scala
@@ -200,8 +200,9 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val license = "publicdomain"
     val articleType = "topic-article"
     val supportedLanguages = Seq("nb", "en")
+    val availability = "everyone"
     val hitString =
-      s"""{  "visualElement": {    "en": "$visualElement"  },  "introduction": {    "nb": "$introduction"  }, "metaImage": [{"imageId": "1", "altText": "$metaImageAlt", "language": "nb"}], "tags": {"nb": ["test"]},  "metaDescription": {    "nb": "$metaDescription"  },  "lastUpdated": "2017-12-29T07:18:27Z",  "tags.nb": [    "baldur"  ],  "license": "$license",  "id": $id,  "authors": [],  "content": {    "nb": "Bilde av Baldurs mareritt om Ragnarok."  },  "defaultTitle": "Baldur har mareritt",  "title": {    "nb": "Baldur har mareritt"  },  "articleType": "$articleType"}"""
+      s"""{  "availability": "everyone", "visualElement": {    "en": "$visualElement"  },  "introduction": {    "nb": "$introduction"  }, "metaImage": [{"imageId": "1", "altText": "$metaImageAlt", "language": "nb"}], "tags": {"nb": ["test"]},  "metaDescription": {    "nb": "$metaDescription"  },  "lastUpdated": "2017-12-29T07:18:27Z",  "tags.nb": [    "baldur"  ],  "license": "$license",  "id": $id,  "authors": [],  "content": {    "nb": "Bilde av Baldurs mareritt om Ragnarok."  },  "defaultTitle": "Baldur har mareritt",  "title": {    "nb": "Baldur har mareritt"  },  "articleType": "$articleType"}"""
 
     val result = service.hitAsArticleSummaryV2(hitString, "nb")
 


### PR DESCRIPTION
Fixes NDLANO/Issues#2609

Kan testes ved å gjøre en request mot apiet etter en artikkel som bare skal vises for lærere feks, og sjekke at den returnerer 404, og ikke dukker opp i søk.
For å teste auth tilgang så må du ha et valid accessToken fra feide og sende det i `FeideAuthorization` headeren.

(Åpen for endring av dette navnet :smile: men å endre til det vanlige `Authorization` krever en jobb i api-gateway, og er kanskje tilogmed litt vanskelig siden vi ikke kan validere uuid'ene på noe vis.)