### PR TITLE
Return 403 if no token.

### DIFF
--- a/src/main/scala/no/ndla/articleapi/service/ReadService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/ReadService.scala
@@ -60,7 +60,7 @@ trait ReadService {
           converterService.toApiArticleV2(article, language, fallback)
         case Some(article) =>
           feideAccessToken match {
-            case None => notFound
+            case None => Failure(AccessDeniedException("User is missing required role(s) to perform this operation"))
             case Some(accessToken) =>
               feideApiClient.getUser(accessToken) match {
                 case Failure(ex) => Failure(ex)


### PR DESCRIPTION
Dersom du kjem utenfra og går rett på adressa, er det bedre om du får 403 enn 404 for en artikkel du ikkje har lov å sjå.