### PR TITLE
Let all search all articles, but still limit fetching.

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -211,8 +211,7 @@ trait ArticleControllerV2 {
         articleTypesFilter,
         fallback,
         grepCodes,
-        shouldScroll,
-        requestFeideToken
+        shouldScroll
       )
 
       result match {

--- a/src/main/scala/no/ndla/articleapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/SearchSettings.scala
@@ -19,6 +19,5 @@ case class SearchSettings(
     articleTypes: Seq[String],
     fallback: Boolean,
     grepCodes: Seq[String],
-    shouldScroll: Boolean,
-    availability: Seq[Availability.Value]
+    shouldScroll: Boolean
 )

--- a/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
+++ b/src/main/scala/no/ndla/articleapi/service/search/ArticleSearchService.scala
@@ -75,11 +75,6 @@ trait ArticleSearchService {
         if (settings.articleTypes.nonEmpty) Some(constantScoreQuery(termsQuery("articleType", settings.articleTypes)))
         else None
 
-      val availabilityFilter =
-        if (settings.availability.isEmpty) Some(termQuery("availability", Availability.everyone.toString))
-        else
-          Some(boolQuery().should(settings.availability.map(a => termQuery("availability", a.toString))))
-
       val idFilter = if (settings.withIdIn.isEmpty) None else Some(idsQuery(settings.withIdIn))
 
       val licenseFilter = settings.license match {
@@ -105,8 +100,7 @@ trait ArticleSearchService {
         idFilter,
         languageFilter,
         articleTypesFilter,
-        grepCodesFilter,
-        availabilityFilter
+        grepCodesFilter
       )
 
       val filteredSearch = queryBuilder.filter(filters.flatten)

--- a/src/test/scala/no/ndla/articleapi/TestData.scala
+++ b/src/test/scala/no/ndla/articleapi/TestData.scala
@@ -10,6 +10,7 @@ package no.ndla.articleapi
 
 import no.ndla.articleapi.ArticleApiProperties.{DefaultLanguage, externalApiUrls}
 import no.ndla.articleapi.model.api
+import no.ndla.articleapi.model.api.{ArticleV2, TagsSearchResult}
 import no.ndla.articleapi.model.domain._
 import no.ndla.mapping.License
 import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
@@ -40,7 +41,7 @@ object TestData {
 
   val (articleId, externalId) = (1, "751234")
 
-  val sampleArticleV2 = api.ArticleV2(
+  val sampleArticleV2: ArticleV2 = api.ArticleV2(
     id = 1,
     oldNdlaUrl = None,
     revision = 1,
@@ -72,7 +73,7 @@ object TestData {
     relatedContent = Seq.empty
   )
 
-  val apiArticleV2 = api.ArticleV2(
+  val apiArticleV2: ArticleV2 = api.ArticleV2(
     articleId,
     Some(s"//red.ndla.no/node/$externalId"),
     2,
@@ -108,7 +109,7 @@ object TestData {
     relatedContent = Seq.empty
   )
 
-  val sampleArticleWithPublicDomain = Article(
+  val sampleArticleWithPublicDomain: Article = Article(
     Option(1),
     Option(1),
     Seq(ArticleTitle("test", "en")),
@@ -131,7 +132,7 @@ object TestData {
     relatedContent = Seq.empty
   )
 
-  val sampleDomainArticle = Article(
+  val sampleDomainArticle: Article = Article(
     Option(articleId),
     Option(2),
     Seq(ArticleTitle("title", "nb")),
@@ -154,7 +155,7 @@ object TestData {
     relatedContent = Seq.empty
   )
 
-  val sampleDomainArticle2 = Article(
+  val sampleDomainArticle2: Article = Article(
     None,
     None,
     Seq(ArticleTitle("test", "en")),
@@ -180,7 +181,7 @@ object TestData {
   val sampleArticleWithByNcSa: Article = sampleArticleWithPublicDomain.copy(copyright = byNcSaCopyright)
   val sampleArticleWithCopyrighted: Article = sampleArticleWithPublicDomain.copy(copyright = copyrighted)
 
-  val sampleDomainArticleWithHtmlFault = Article(
+  val sampleDomainArticleWithHtmlFault: Article = Article(
     Option(articleId),
     Option(2),
     Seq(ArticleTitle("test", "en")),
@@ -211,7 +212,7 @@ object TestData {
     relatedContent = Seq.empty
   )
 
-  val apiArticleWithHtmlFaultV2 = api.ArticleV2(
+  val apiArticleWithHtmlFaultV2: ArticleV2 = api.ArticleV2(
     1,
     None,
     1,
@@ -244,9 +245,9 @@ object TestData {
   )
 
   val (nodeId, nodeId2) = ("1234", "4321")
-  val sampleTitle = ArticleTitle("title", "en")
+  val sampleTitle: ArticleTitle = ArticleTitle("title", "en")
 
-  val visualElement = VisualElement(
+  val visualElement: VisualElement = VisualElement(
     s"""<$ResourceHtmlEmbedTag  data-align="" data-alt="" data-caption="" data-resource="image" data-resource_id="1" data-size="" />""",
     "nb")
 
@@ -275,9 +276,9 @@ object TestData {
     )
   }
 
-  val sampleApiTagsSearchResult = api.TagsSearchResult(10, 1, 1, "nb", Seq("a", "b"))
+  val sampleApiTagsSearchResult: TagsSearchResult = api.TagsSearchResult(10, 1, 1, "nb", Seq("a", "b"))
 
-  val testSettings = SearchSettings(
+  val testSettings: SearchSettings = SearchSettings(
     query = None,
     withIdIn = List(),
     language = DefaultLanguage,
@@ -288,8 +289,7 @@ object TestData {
     articleTypes = Seq.empty,
     fallback = false,
     grepCodes = Seq.empty,
-    shouldScroll = false,
-    availability = Seq.empty
+    shouldScroll = false
   )
 
 }

--- a/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -83,7 +83,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       Seq.empty[ArticleSummaryV2],
       Some(scrollId)
     )
-    when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any))
+    when(readService.search(any, any, any, any, any, any, any, any, any, any, any))
       .thenReturn(Success(searchResponse))
 
     get(s"/test/") {
@@ -113,7 +113,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
     }
 
     verify(articleSearchService, times(0)).matchingQuery(any[SearchSettings])
-    verify(readService, times(0)).search(any, any, any, any, any, any, any, any, any, any, any, any)
+    verify(readService, times(0)).search(any, any, any, any, any, any, any, any, any, any, any)
     verify(articleSearchService, times(1)).scroll(eqTo(scrollId), any[String], any[Boolean])
   }
 
@@ -172,7 +172,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       results = Seq.empty,
       scrollId = Some("heiheihei")
     )
-    when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any)).thenReturn(Success(result))
+    when(readService.search(any, any, any, any, any, any, any, any, any, any, any)).thenReturn(Success(result))
 
     get("/test/?search-context=initial") {
       status should be(200)
@@ -187,8 +187,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
         articleTypesFilter = any,
         fallback = any,
         grepCodes = any,
-        shouldScroll = eqTo(true),
-        feideAccessToken = any
+        shouldScroll = eqTo(true)
       )
       verify(articleSearchService, times(0)).scroll(any[String], any[String], any[Boolean])
     }

--- a/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
@@ -149,8 +149,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
       articleTypesFilter = Seq.empty,
       fallback = false,
       grepCodes = Seq.empty,
-      shouldScroll = false,
-      feideAccessToken = None
+      shouldScroll = false
     )
 
     val expectedSettings = SearchSettings(
@@ -164,8 +163,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
       ArticleType.all,
       fallback = false,
       grepCodes = Seq.empty,
-      shouldScroll = false,
-      availability = Seq.empty
+      shouldScroll = false
     )
 
     verify(articleSearchService, times(1)).matchingQuery(expectedSettings)

--- a/src/test/scala/no/ndla/articleapi/service/search/ArticleSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/search/ArticleSearchServiceTest.scala
@@ -265,35 +265,35 @@ class ArticleSearchServiceTest
     results.totalCount should be(3)
 
     val Success(results2) = articleSearchService.matchingQuery(testSettings.copy(articleTypes = Seq.empty))
-    results2.totalCount should be(9)
+    results2.totalCount should be(11)
   }
 
   test("That searching without query returns all documents ordered by id ascending") {
     val Success(results) =
       articleSearchService.matchingQuery(testSettings.copy(query = None))
     val hits = results.results
-    results.totalCount should be(9)
+    results.totalCount should be(11)
     hits.head.id should be(1)
     hits(1).id should be(2)
     hits(2).id should be(3)
     hits(3).id should be(5)
     hits(4).id should be(6)
     hits(5).id should be(7)
-    hits.last.id should be(11)
+    hits.last.id should be(12)
   }
 
   test("That searching returns all documents ordered by id descending") {
     val Success(results) = articleSearchService.matchingQuery(testSettings.copy(sort = Sort.ByIdDesc))
     val hits = results.results
-    results.totalCount should be(9)
-    hits.head.id should be(11)
-    hits.last.id should be(1)
+    results.totalCount should be(11)
+    hits.head.id should be(13)
+    hits.last.id should be(2)
   }
 
   test("That searching returns all documents ordered by title ascending") {
     val Success(results) = articleSearchService.matchingQuery(testSettings.copy(sort = Sort.ByTitleAsc))
     val hits = results.results
-    results.totalCount should be(9)
+    results.totalCount should be(11)
     hits.head.id should be(8)
     hits(1).id should be(1)
     hits(2).id should be(3)
@@ -302,52 +302,55 @@ class ArticleSearchServiceTest
     hits(5).id should be(11)
     hits(6).id should be(6)
     hits(7).id should be(2)
-    hits.last.id should be(7)
+    hits.last.id should be(12)
   }
 
   test("That searching returns all documents ordered by title descending") {
     val Success(results) = articleSearchService.matchingQuery(testSettings.copy(sort = Sort.ByTitleDesc))
     val hits = results.results
-    results.totalCount should be(9)
-    hits.head.id should be(7)
-    hits(1).id should be(2)
-    hits(2).id should be(6)
-    hits(3).id should be(11)
-    hits(4).id should be(5)
-    hits(5).id should be(9)
-    hits(6).id should be(3)
-    hits(7).id should be(1)
-    hits.last.id should be(8)
+    results.totalCount should be(11)
+    hits.head.id should be(13)
+    hits(1).id should be(12)
+    hits(2).id should be(7)
+    hits(3).id should be(2)
+    hits(4).id should be(6)
+    hits(5).id should be(11)
+    hits(6).id should be(5)
+    hits(7).id should be(9)
+    hits(8).id should be(3)
+    hits(9).id should be(1)
+    hits.last.id should be(1)
   }
 
   test("That searching returns all documents ordered by lastUpdated descending") {
     val results = articleSearchService.matchingQuery(testSettings.copy(sort = Sort.ByLastUpdatedDesc))
     val hits = results.get.results
-    results.get.totalCount should be(9)
+    results.get.totalCount should be(11)
     hits.head.id should be(3)
-    hits.last.id should be(5)
+    hits.last.id should be(6)
   }
 
   test("That all returns all documents ordered by lastUpdated ascending") {
     val Success(results) = articleSearchService.matchingQuery(testSettings.copy(sort = Sort.ByLastUpdatedAsc))
     val hits = results.results
-    results.totalCount should be(9)
+    results.totalCount should be(11)
     hits.head.id should be(5)
     hits(1).id should be(6)
     hits(2).id should be(7)
     hits(3).id should be(8)
     hits(4).id should be(9)
-    hits(5).id should be(11)
-    hits(6).id should be(1)
-    hits(7).id should be(2)
-    hits.last.id should be(3)
+    hits(5).id should be(12)
+    hits(6).id should be(13)
+    hits(7).id should be(11)
+    hits(8).id should be(1)
+    hits.last.id should be(2)
   }
 
   test("That all filtering on license only returns documents with given license") {
     val Success(results) = articleSearchService.matchingQuery(
       testSettings.copy(sort = Sort.ByTitleAsc, license = Some(PublicDomain.toString)))
     val hits = results.results
-    results.totalCount should be(8)
+    results.totalCount should be(10)
     hits.head.id should be(8)
     hits(1).id should be(3)
     hits(2).id should be(9)
@@ -355,7 +358,7 @@ class ArticleSearchServiceTest
     hits(4).id should be(11)
     hits(5).id should be(6)
     hits(6).id should be(2)
-    hits.last.id should be(7)
+    hits.last.id should be(13)
   }
 
   test("That all filtered by id only returns documents with the given ids") {
@@ -374,12 +377,12 @@ class ArticleSearchServiceTest
 
     val hits1 = page1.results
     val hits2 = page2.results
-    page1.totalCount should be(9)
+    page1.totalCount should be(11)
     page1.page.get should be(1)
     hits1.size should be(2)
     hits1.head.id should be(8)
     hits1.last.id should be(1)
-    page2.totalCount should be(9)
+    page2.totalCount should be(11)
     page2.page.get should be(2)
     hits2.size should be(2)
     hits2.head.id should be(3)
@@ -479,7 +482,7 @@ class ArticleSearchServiceTest
   test("Search for all languages should return all articles in different languages") {
     val Success(search) = articleSearchService.matchingQuery(
       testSettings.copy(language = Language.AllLanguages, pageSize = 100, sort = Sort.ByTitleAsc))
-    search.totalCount should equal(10)
+    search.totalCount should equal(12)
   }
 
   test("Search for all languages should return all articles in correct language") {
@@ -487,7 +490,7 @@ class ArticleSearchServiceTest
       articleSearchService.matchingQuery(testSettings.copy(language = Language.AllLanguages, pageSize = 100))
     val hits = search.results
 
-    search.totalCount should equal(10)
+    search.totalCount should equal(12)
     hits(0).id should equal(1)
     hits(1).id should equal(2)
     hits(2).id should equal(3)
@@ -589,7 +592,7 @@ class ArticleSearchServiceTest
 
   test("That scrolling works as expected") {
     val pageSize = 2
-    val expectedIds = List(1, 2, 3, 5, 6, 7, 8, 9, 10, 11).sliding(pageSize, pageSize).toList
+    val expectedIds = List(1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13).sliding(pageSize, pageSize).toList
 
     val Success(initialSearch) =
       articleSearchService.matchingQuery(
@@ -611,7 +614,7 @@ class ArticleSearchServiceTest
     scroll2.results.map(_.id) should be(expectedIds(2))
     scroll3.results.map(_.id) should be(expectedIds(3))
     scroll4.results.map(_.id) should be(expectedIds(4))
-    scroll5.results.map(_.id) should be(List.empty)
+    scroll5.results.map(_.id) should be(expectedIds(5))
   }
 
   test("That highlighting works when scrolling") {
@@ -647,32 +650,6 @@ class ArticleSearchServiceTest
     val Success(search3) = articleSearchService.matchingQuery(testSettings.copy(grepCodes = Seq("KV456")))
     search3.totalCount should be(3)
     search3.results.map(_.id) should be(Seq(1, 2, 3))
-  }
-
-  test("That 'everyone' doesn't see teacher and student articles in search") {
-    val Success(search1) = articleSearchService.matchingQuery(
-      testSettings.copy(query = Some("availability"), availability = Seq(Availability.everyone)))
-
-    val Success(search2) =
-      articleSearchService.matchingQuery(testSettings.copy(query = Some("availability"), availability = Seq.empty))
-
-    search1.results should be(Seq.empty)
-    search2.results should be(Seq.empty)
-  }
-
-  test("That 'students' doesn't see teacher articles in search") {
-    val Success(search1) = articleSearchService.matchingQuery(
-      testSettings.copy(query = Some("availability"), availability = Seq(Availability.student, Availability.everyone)))
-
-    search1.results.map(_.id) should be(Seq(13))
-  }
-
-  test("That 'teachers' sees teacher articles in search") {
-    val Success(search1) = articleSearchService.matchingQuery(
-      testSettings.copy(query = Some("availability"),
-                        availability = Seq(Availability.teacher, Availability.student, Availability.everyone)))
-
-    search1.results.map(_.id) should be(Seq(12, 13))
   }
 
   def blockUntil(predicate: () => Boolean): Unit = {


### PR DESCRIPTION
Alle artikler er søkbare uavhengig av tilgjengelighet. Article-api brukes hos oss kun for å sjekke om artikkelen finnes eller ei ved filtrering av taksonomi. Vi kan fremdeles ha denne funksjonen i search-api men det gir meining å fjerne i artice-api.

Test:
Alle artikler skal dukke opp i søk sjølv om du ikkje har tilgang til så hente dei.