### PR TITLE
Introduce `Cachable` class to avoid caching restricted content

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/ArticleControllerV2.scala
@@ -217,8 +217,8 @@ trait ArticleControllerV2 {
 
       result match {
         case Success(searchResult) =>
-          val responseHeader = searchResult.scrollId.map(i => this.scrollId.paramName -> i).toMap
-          Ok(searchConverterService.asApiSearchResultV2(searchResult), headers = responseHeader)
+          val scrollHeader = searchResult.value.scrollId.map(i => this.scrollId.paramName -> i).toMap
+          searchResult.map(searchConverterService.asApiSearchResultV2).Ok(scrollHeader)
         case Failure(ex) => Failure(ex)
       }
 
@@ -357,8 +357,8 @@ trait ArticleControllerV2 {
           val revision = inlineRevision.orElse(intOrNone(this.revision.paramName))
 
           readService.withIdV2(articleId, language, fallback, revision, requestFeideToken) match {
-            case Success(article) => article
-            case Failure(ex)      => errorHandler(ex)
+            case Success(cachableArticle) => cachableArticle.Ok()
+            case Failure(ex)              => errorHandler(ex)
           }
       }
     }

--- a/src/main/scala/no/ndla/articleapi/model/domain/Cachable.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/Cachable.scala
@@ -1,0 +1,85 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.articleapi.model.domain
+
+import org.scalatra
+import org.scalatra.ActionResult
+
+import scala.util.Try
+
+/** Wrapper class for content that can have different cachability attributes based on the content
+  * Useful for Articles that require login
+  *
+  * One would use the class by using `Cachable.yes(value)` (Or `Cachable.no(value)`) for values that can be cached
+  * and then use `returnValue.Ok()` in the controller to get the scalatra type with headers.
+  */
+case class Cachable[T](
+    value: T,
+    canBeCached: Boolean
+) {
+
+  /** Return the value wrapped in a [[org.scalatra.Ok]] with the correct 'cache-control' header applied. */
+  def Ok(headers: Map[String, String] = Map.empty): ActionResult = {
+    val cacheHeaders = if (canBeCached) Map.empty else Map("Cache-Control" -> "private")
+    scalatra.Ok(value, headers = headers ++ cacheHeaders)
+  }
+
+  /** Return a [[Cachable]] object with the function applied to value
+    * Example:
+    * ```
+    * val a = Cachable.yes("TestString")
+    * val b = a.map(s => s.toLowerCase())
+    *
+    * // a.value = "TestString"
+    * // b.value = "teststring"
+    * ```
+    */
+  def map[U](f: T => U): Cachable[U] = {
+    copy(value = f(value))
+  }
+
+  def flatMap[U](f: T => Cachable[U]): Cachable[U] = {
+    f(value)
+  }
+}
+
+object Cachable {
+
+  def yes[T <: Try[U], U](value: T): Try[Cachable[U]] = {
+    value.map(
+      v =>
+        new Cachable(
+          value = v,
+          canBeCached = true
+      ))
+  }
+
+  def no[T <: Try[U], U](value: T): Try[Cachable[U]] = {
+    value.map(
+      v =>
+        new Cachable(
+          value = v,
+          canBeCached = false
+      ))
+  }
+
+  def yes[T](value: T): Cachable[T] = {
+    new Cachable(
+      value = value,
+      canBeCached = true
+    )
+  }
+
+  def no[T](value: T): Cachable[T] = {
+    new Cachable(
+      value = value,
+      canBeCached = false
+    )
+  }
+}

--- a/src/main/scala/no/ndla/articleapi/model/domain/Cachable.scala
+++ b/src/main/scala/no/ndla/articleapi/model/domain/Cachable.scala
@@ -51,35 +51,21 @@ case class Cachable[T](
 
 object Cachable {
 
-  def yes[T <: Try[U], U](value: T): Try[Cachable[U]] = {
-    value.map(
-      v =>
-        new Cachable(
-          value = v,
-          canBeCached = true
-      ))
-  }
+  def yes[T <: Try[U], U](value: T): Try[Cachable[U]] =
+    value.map(v => Cachable.yes(v))
 
-  def no[T <: Try[U], U](value: T): Try[Cachable[U]] = {
-    value.map(
-      v =>
-        new Cachable(
-          value = v,
-          canBeCached = false
-      ))
-  }
+  def no[T <: Try[U], U](value: T): Try[Cachable[U]] =
+    value.map(v => Cachable.no(v))
 
-  def yes[T](value: T): Cachable[T] = {
+  def yes[T](value: T): Cachable[T] =
     new Cachable(
       value = value,
       canBeCached = true
     )
-  }
 
-  def no[T](value: T): Cachable[T] = {
+  def no[T](value: T): Cachable[T] =
     new Cachable(
       value = value,
       canBeCached = false
     )
-  }
 }

--- a/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
+++ b/src/test/scala/no/ndla/articleapi/controller/ArticleControllerV2Test.scala
@@ -51,7 +51,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
   val articleId = 1
 
   test("/<article_id> should return 200 if the cover was found withIdV2") {
-    when(readService.withIdV2(articleId, lang)).thenReturn(Success(TestData.sampleArticleV2))
+    when(readService.withIdV2(articleId, lang)).thenReturn(Success(Cachable.yes(TestData.sampleArticleV2)))
 
     get(s"/test/$articleId?language=$lang") {
       status should equal(200)
@@ -84,7 +84,7 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       Some(scrollId)
     )
     when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any))
-      .thenReturn(Success(searchResponse))
+      .thenReturn(Success(Cachable.yes(searchResponse)))
 
     get(s"/test/") {
       status should be(200)
@@ -172,7 +172,8 @@ class ArticleControllerV2Test extends UnitSuite with TestEnvironment with Scalat
       results = Seq.empty,
       scrollId = Some("heiheihei")
     )
-    when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any)).thenReturn(Success(result))
+    when(readService.search(any, any, any, any, any, any, any, any, any, any, any, any))
+      .thenReturn(Success(Cachable.yes(result)))
 
     get("/test/?search-context=initial") {
       status should be(200)

--- a/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
+++ b/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Part of NDLA article-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.articleapi.model
+
+import no.ndla.articleapi._
+import no.ndla.articleapi.model.domain.Cachable
+
+class CachableTest extends UnitSuite with TestEnvironment {
+  test("That map works as expected") {
+    val c1: Cachable[Int] = Cachable.no(1)
+    c1.map(x => x+5) should be(Cachable(6, false))
+  }
+
+  test("That for-comprehensions (flatMap) works as expected") {
+    val c1: Cachable[Int] = Cachable.yes(1)
+    val c2: Cachable[Int] = Cachable.yes(2)
+    val c3: Cachable[Int] = Cachable.yes(3)
+
+    val x = for {
+      a <- c1
+      b <- c2
+      c <- c3
+    } yield (a+b+c)
+
+    x should be(Cachable(6, true))
+  }
+}

--- a/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
+++ b/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
@@ -14,7 +14,7 @@ import no.ndla.articleapi.model.domain.Cachable
 class CachableTest extends UnitSuite with TestEnvironment {
   test("That map works as expected") {
     val c1: Cachable[Int] = Cachable.no(1)
-    c1.map(x => x+5) should be(Cachable(6, false))
+    c1.map(x => x + 5) should be(Cachable(6, false))
   }
 
   test("That for-comprehensions (flatMap) works as expected") {
@@ -26,7 +26,7 @@ class CachableTest extends UnitSuite with TestEnvironment {
       a <- c1
       b <- c2
       c <- c3
-    } yield (a+b+c)
+    } yield (a + b + c)
 
     x should be(Cachable(6, true))
   }

--- a/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
+++ b/src/test/scala/no/ndla/articleapi/model/CachableTest.scala
@@ -11,6 +11,8 @@ package no.ndla.articleapi.model
 import no.ndla.articleapi._
 import no.ndla.articleapi.model.domain.Cachable
 
+import scala.util.{Success, Try}
+
 class CachableTest extends UnitSuite with TestEnvironment {
   test("That map works as expected") {
     val c1: Cachable[Int] = Cachable.no(1)
@@ -29,5 +31,15 @@ class CachableTest extends UnitSuite with TestEnvironment {
     } yield (a + b + c)
 
     x should be(Cachable(6, true))
+  }
+
+  test("That constructors for both `Try` and others works as expected") {
+    val t1 = Success(1)
+    val c1: Try[Cachable[Int]] = Cachable.yes(t1)
+    c1 should be(Success(Cachable(1, true)))
+
+    val t2 = Success(2)
+    val c2: Cachable[Try[Int]] = Cachable.yes(t2)
+    c2 should be(Cachable(Success(2), true))
   }
 }

--- a/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
+++ b/src/test/scala/no/ndla/articleapi/service/ReadServiceTest.scala
@@ -16,6 +16,7 @@ import no.ndla.articleapi.model.domain.{
   ArticleContent,
   ArticleTag,
   ArticleType,
+  Cachable,
   Language,
   SearchSettings,
   Sort,
@@ -28,7 +29,7 @@ import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
 import scalikejdbc.DBSession
 
-import scala.util.Success
+import scala.util.{Success, Try}
 
 class ReadServiceTest extends UnitSuite with TestEnvironment {
 
@@ -69,10 +70,10 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     when(articleRepository.withId(1)).thenReturn(Option(article))
     when(articleRepository.getExternalIdsFromId(any[Long])(any[DBSession])).thenReturn(List("54321"))
 
-    val expectedResult = converterService.toApiArticleV2(article.copy(content = Seq(expectedArticleContent1),
-                                                                      visualElement =
-                                                                        Seq(VisualElement(visualElementAfter, "nb"))),
-                                                         "nb")
+    val expectedResult: Try[Cachable[api.ArticleV2]] = Cachable.yes(
+      converterService.toApiArticleV2(article.copy(content = Seq(expectedArticleContent1),
+                                                   visualElement = Seq(VisualElement(visualElementAfter, "nb"))),
+                                      "nb"))
     readService.withIdV2(1, "nb") should equal(expectedResult)
   }
 


### PR DESCRIPTION
Denne infører en hjemmelaget klasse `Cachable` for å ha kontroll på hvorvidt et resultat fra en respons skal caches eller ei.
Kan testes ved å sjekke at artikler med annen `availability` enn `everyone` vil inkludere en `cache-control: private` i responsheaderen. 

Vi burde nok også finne på noe "andre veien" (i api-gateway), sånn at folk med tilganger ikke ender opp med en respons med for lite innhold fra en cache.
For eksempel ved å inkludere feide-tokenet i cache-key'en. Det vil gjøre cachen litt mindre effektiv, men da vil i alle fall innholdet være riktig.