### PR TITLE
Ignore errors when fetching userinformation from feide

### DIFF
--- a/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/articleapi/controller/NdlaController.scala
@@ -55,6 +55,7 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
   }
 
   error {
+    case a: AccessDeniedException if a.unauthorized   => Unauthorized(body = Error(Error.ACCESS_DENIED, a.getMessage))
     case a: AccessDeniedException                     => Forbidden(body = Error(Error.ACCESS_DENIED, a.getMessage))
     case v: ValidationException                       => BadRequest(body = ValidationError(messages = v.errors))
     case _: IndexNotFoundException                    => InternalServerError(body = Error.IndexMissingError)

--- a/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
+++ b/src/main/scala/no/ndla/articleapi/model/api/NDLAErrors.scala
@@ -59,7 +59,7 @@ case class NotFoundException(message: String, supportedLanguages: Seq[String] = 
     extends RuntimeException(message)
 case class ImportException(message: String) extends RuntimeException(message)
 
-case class AccessDeniedException(message: String) extends RuntimeException(message)
+case class AccessDeniedException(message: String, unauthorized: Boolean = false) extends RuntimeException(message)
 class ImportExceptions(val message: String, val errors: Seq[Throwable]) extends RuntimeException(message)
 class ConfigurationException(message: String) extends RuntimeException(message)
 case class SearchException(message: String) extends RuntimeException(message)


### PR DESCRIPTION
Dette vil gjøre at et søk med et invalid feidetoken vil oppføre seg som et vanlig søk uten token :^)

Kan testes ved å spinne opp apiet og gjøre et søk med et invalid feidetoken.